### PR TITLE
mm-fastq-gz: Tweaks to storage usage for alignments

### DIFF
--- a/docs/adr.rst
+++ b/docs/adr.rst
@@ -36,3 +36,8 @@ The disabling of pylint test for determining if a function should be a static me
 -------------------------------
 
 Based on benchmarking of the pipeline the procedure for merging of bam files has been modified to get an optimal balance between running as much as possible in parallel vs the cost of spinning up new jobs to perform the merging. It was found that running each job merging 10 files provided the break even point between the cost of creating a new job and getting the maximum throughput through the system. It also reduces the number of iterative merge procedures which is beneficial when there are alignments that are difficult to merge.
+
+2018-05-01 - Compression of FASTQ
+---------------------------------
+
+Added compression of the split FASTQ files to reduce the amount of space required when processing the data.

--- a/docs/adr.rst
+++ b/docs/adr.rst
@@ -40,4 +40,4 @@ Based on benchmarking of the pipeline the procedure for merging of bam files has
 2018-05-01 - Compression of FASTQ
 ---------------------------------
 
-Added compression of the split FASTQ files to reduce the amount of space required when processing the data.
+Added compression of the split FASTQ files to reduce the amount of space required when processing the data. There is also the removal of the tmp directory after the completion of the splitter to save on space.

--- a/tests/test_bowtie2_aligner.py
+++ b/tests/test_bowtie2_aligner.py
@@ -16,13 +16,15 @@
 """
 from __future__ import print_function
 
-import os.path
+import os
+import shutil
 import gzip
 import pytest
 
 from basic_modules.metadata import Metadata
 
 from tool.bowtie_aligner import bowtie2AlignerTool
+
 
 @pytest.mark.bowtie2
 def test_bowtie2_aligner_00():
@@ -44,6 +46,7 @@ def test_bowtie2_aligner_00():
     assert os.path.getsize(fastq_file_1) > 0
     assert os.path.isfile(fastq_file_2) is True
     assert os.path.getsize(fastq_file_2) > 0
+
 
 @pytest.mark.bowtie2
 def test_bowtie2_aligner_single():
@@ -96,6 +99,7 @@ def test_bowtie2_aligner_single():
         shutil.rmtree(resource_path + "tmp")
     except OSError, ose:
         print("Error: %s - %s." % (ose.filename, ose.strerror))
+
 
 @pytest.mark.bowtie2
 def test_bowtie2_aligner_paired():

--- a/tests/test_bowtie2_aligner.py
+++ b/tests/test_bowtie2_aligner.py
@@ -87,6 +87,16 @@ def test_bowtie2_aligner_single():
     assert os.path.isfile(resource_path + "macs2.Human.DRR000150.22_bt2.bam") is True
     assert os.path.getsize(resource_path + "macs2.Human.DRR000150.22_bt2.bam") > 0
 
+    try:
+        os.remove(resource_path + "macs2.Human.DRR000150.22_bt2.bam")
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
+
+    try:
+        shutil.rmtree(resource_path + "tmp")
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
+
 @pytest.mark.bowtie2
 def test_bowtie2_aligner_paired():
     """
@@ -136,3 +146,13 @@ def test_bowtie2_aligner_paired():
 
     assert os.path.isfile(resource_path + "bsSeeker.Mouse.SRR892982_1_bt2.bam") is True
     assert os.path.getsize(resource_path + "bsSeeker.Mouse.SRR892982_1_bt2.bam") > 0
+
+    try:
+        os.remove(resource_path + "bsSeeker.Mouse.SRR892982_1_bt2.bam")
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
+
+    try:
+        shutil.rmtree(resource_path + "tmp")
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))

--- a/tests/test_bwa_aligner.py
+++ b/tests/test_bwa_aligner.py
@@ -118,13 +118,14 @@ def test_bwa_aligner_aln():
 
     try:
         os.remove(resource_path + "macs2.Human.DRR000150.22_mem.bam")
-    except OSError, e:
-        print("Error: %s - %s." % (e.filename, e.strerror))
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
 
     try:
         shutil.rmtree(resource_path + "tmp")
-    except OSError, e:
-        print("Error: %s - %s." % (e.filename, e.strerror))
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
+
 
 @pytest.mark.bwa
 def test_bwa_aligner_mem():
@@ -172,13 +173,14 @@ def test_bwa_aligner_mem():
 
     try:
         os.remove(resource_path + "macs2.Human.DRR000150.22_mem.bam")
-    except OSError, e:
-        print("Error: %s - %s." % (e.filename, e.strerror))
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
 
     try:
         shutil.rmtree(resource_path + "tmp")
-    except OSError, e:
-        print("Error: %s - %s." % (e.filename, e.strerror))
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
+
 
 @pytest.mark.bwa
 def test_bwa_aligner_00():
@@ -200,6 +202,7 @@ def test_bwa_aligner_00():
     assert os.path.getsize(fastq_file_1) > 0
     assert os.path.isfile(fastq_file_2) is True
     assert os.path.getsize(fastq_file_2) > 0
+
 
 @pytest.mark.bwa
 def test_bwa_aligner_aln_paired():
@@ -253,13 +256,14 @@ def test_bwa_aligner_aln_paired():
 
     try:
         os.remove(resource_path + "bsSeeker.Mouse.SRR892982_1_aln.bam")
-    except OSError, e:
-        print("Error: %s - %s." % (e.filename, e.strerror))
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
 
     try:
         shutil.rmtree(resource_path + "tmp")
-    except OSError, e:
-        print("Error: %s - %s." % (e.filename, e.strerror))
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
+
 
 @pytest.mark.bwa
 def test_bwa_aligner_mem_paired():
@@ -313,16 +317,17 @@ def test_bwa_aligner_mem_paired():
 
     try:
         os.remove(resource_path + "bsSeeker.Mouse.SRR892982_1_mem.bam")
-    except OSError, e:
-        print("Error: %s - %s." % (e.filename, e.strerror))
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
 
     try:
         shutil.rmtree(resource_path + "tmp")
-    except OSError, e:
-        print("Error: %s - %s." % (e.filename, e.strerror))
+    except OSError, ose:
+        print("Error: %s - %s." % (ose.filename, ose.strerror))
+
 
 @pytest.mark.idamidseq
-#@pytest.mark.bwa
+# @pytest.mark.bwa
 def test_bwa_aligner_idamidseq():
     """
     Function to test BWA Aligner
@@ -379,6 +384,7 @@ def test_bwa_aligner_idamidseq():
 
         assert os.path.isfile(fastq_file.replace(".fastq", ".bam")) is True
         assert os.path.getsize(fastq_file.replace(".fastq", ".bam")) > 0
+
 
 @pytest.mark.mnaseseq
 @pytest.mark.bwa

--- a/tests/test_bwa_aligner.py
+++ b/tests/test_bwa_aligner.py
@@ -16,17 +16,18 @@
 """
 from __future__ import print_function
 
-import os.path
+import os
+import shutil
 import gzip
-import pytest # pylint: disable=unused-import
+import pytest  # pylint: disable=unused-import
 
 from basic_modules.metadata import Metadata
 
 from tool.bwa_aligner import bwaAlignerTool
 from tool.bwa_mem_aligner import bwaAlignerMEMTool
 
+
 @pytest.mark.chipseq
-@pytest.mark.bwa
 def test_bwa_aligner_chipseq_aln():
     """
     Function to test BWA Aligner
@@ -70,8 +71,63 @@ def test_bwa_aligner_chipseq_aln():
     assert os.path.isfile(resource_path + "macs2.Human.DRR000150.22_aln.bam") is True
     assert os.path.getsize(resource_path + "macs2.Human.DRR000150.22_aln.bam") > 0
 
+
 @pytest.mark.bwa
-def test_bwa_aligner_chipseq_mem():
+def test_bwa_aligner_aln():
+    """
+    Function to test BWA Aligner
+    """
+    resource_path = os.path.join(os.path.dirname(__file__), "data/")
+    genome_fa = resource_path + "macs2.Human.GCA_000001405.22.fasta"
+    fastq_file = resource_path + "macs2.Human.DRR000150.22.fastq"
+
+    input_files = {
+        "genome": genome_fa,
+        "index": genome_fa + ".bwa.tar.gz",
+        "loc": fastq_file
+    }
+
+    output_files = {
+        "output": fastq_file.replace(".fastq", "_aln.bam")
+    }
+
+    metadata = {
+        "genome": Metadata(
+            "Assembly", "fasta", genome_fa, None,
+            {"assembly": "test"}),
+        "index": Metadata(
+            "index_bwa", "", [genome_fa],
+            {
+                "assembly": "test",
+                "tool": "bwa_indexer"
+            }
+        ),
+        "loc": Metadata(
+            "data_chip_seq", "fastq", fastq_file, None,
+            {"assembly": "test"}
+        )
+    }
+
+    bwa_t = bwaAlignerTool()
+    bwa_t.run(input_files, metadata, output_files)
+
+    print(__file__)
+
+    assert os.path.isfile(resource_path + "macs2.Human.DRR000150.22_aln.bam") is True
+    assert os.path.getsize(resource_path + "macs2.Human.DRR000150.22_aln.bam") > 0
+
+    try:
+        os.remove(resource_path + "macs2.Human.DRR000150.22_mem.bam")
+    except OSError, e:
+        print("Error: %s - %s." % (e.filename, e.strerror))
+
+    try:
+        shutil.rmtree(resource_path + "tmp")
+    except OSError, e:
+        print("Error: %s - %s." % (e.filename, e.strerror))
+
+@pytest.mark.bwa
+def test_bwa_aligner_mem():
     """
     Function to test BWA Aligner
     """
@@ -113,6 +169,16 @@ def test_bwa_aligner_chipseq_mem():
 
     assert os.path.isfile(resource_path + "macs2.Human.DRR000150.22_mem.bam") is True
     assert os.path.getsize(resource_path + "macs2.Human.DRR000150.22_mem.bam") > 0
+
+    try:
+        os.remove(resource_path + "macs2.Human.DRR000150.22_mem.bam")
+    except OSError, e:
+        print("Error: %s - %s." % (e.filename, e.strerror))
+
+    try:
+        shutil.rmtree(resource_path + "tmp")
+    except OSError, e:
+        print("Error: %s - %s." % (e.filename, e.strerror))
 
 @pytest.mark.bwa
 def test_bwa_aligner_00():
@@ -185,6 +251,16 @@ def test_bwa_aligner_aln_paired():
     assert os.path.isfile(resource_path + "bsSeeker.Mouse.SRR892982_1_aln.bam") is True
     assert os.path.getsize(resource_path + "bsSeeker.Mouse.SRR892982_1_aln.bam") > 0
 
+    try:
+        os.remove(resource_path + "bsSeeker.Mouse.SRR892982_1_aln.bam")
+    except OSError, e:
+        print("Error: %s - %s." % (e.filename, e.strerror))
+
+    try:
+        shutil.rmtree(resource_path + "tmp")
+    except OSError, e:
+        print("Error: %s - %s." % (e.filename, e.strerror))
+
 @pytest.mark.bwa
 def test_bwa_aligner_mem_paired():
     """
@@ -234,6 +310,16 @@ def test_bwa_aligner_mem_paired():
 
     assert os.path.isfile(resource_path + "bsSeeker.Mouse.SRR892982_1_mem.bam") is True
     assert os.path.getsize(resource_path + "bsSeeker.Mouse.SRR892982_1_mem.bam") > 0
+
+    try:
+        os.remove(resource_path + "bsSeeker.Mouse.SRR892982_1_mem.bam")
+    except OSError, e:
+        print("Error: %s - %s." % (e.filename, e.strerror))
+
+    try:
+        shutil.rmtree(resource_path + "tmp")
+    except OSError, e:
+        print("Error: %s - %s." % (e.filename, e.strerror))
 
 @pytest.mark.idamidseq
 #@pytest.mark.bwa

--- a/tool/aligner_utils.py
+++ b/tool/aligner_utils.py
@@ -22,7 +22,6 @@ import os.path
 
 from utils import logger
 from tool.common import cd
-from tool.bam_utils import bamUtils
 
 
 class alignerUtils(object):

--- a/tool/aligner_utils.py
+++ b/tool/aligner_utils.py
@@ -215,6 +215,8 @@ class alignerUtils(object):
                 msg.errno, msg.strerror, cmd_view))
             return False
 
+        os.remove(reads_file_1 + '.sam')
+
         return True
 
     @staticmethod
@@ -271,6 +273,9 @@ class alignerUtils(object):
             logger.fatal("BWA ALN stdout" + proc_out)
             logger.fatal("BWA ALN stderr" + proc_err)
             return False
+
+        os.remove(reads_file + '.sam')
+        os.remove(reads_file + '.sai')
 
         return True
 
@@ -331,6 +336,9 @@ class alignerUtils(object):
                 msg.errno, msg.strerror, command_line))
             return False
 
+        os.remove(reads_file_1 + '.sam')
+        os.remove(reads_file_1 + '.sai')
+        os.remove(reads_file_2 + '.sai')
         return True
 
     @staticmethod
@@ -384,5 +392,7 @@ class alignerUtils(object):
             logger.info("I/O error({0}): {1}\n{2}".format(
                 msg.errno, msg.strerror, cmd_view))
             return False
+
+        os.remove(reads_file_1 + '.sam')
 
         return True

--- a/tool/aligner_utils.py
+++ b/tool/aligner_utils.py
@@ -188,7 +188,7 @@ class alignerUtils(object):
             ' '.join(params),
         ] + reads)
 
-        cmd_view = ' '.join([
+        cmd_sort = ' '.join([
             'samtools sort',
             '-O bam',
             '-o', bam_loc,
@@ -206,12 +206,12 @@ class alignerUtils(object):
             return False
 
         try:
-            logger.info("BOWTIE2 COMMAND: " + cmd_view)
-            process = subprocess.Popen(cmd_view, shell=True)
+            logger.info("BOWTIE2 COMMAND: " + cmd_sort)
+            process = subprocess.Popen(cmd_sort, shell=True)
             process.wait()
         except (IOError, OSError) as msg:
             logger.info("I/O error({0}): {1}\n{2}".format(
-                msg.errno, msg.strerror, cmd_view))
+                msg.errno, msg.strerror, cmd_sort))
             return False
 
         os.remove(reads_file_1 + '.sam')
@@ -246,14 +246,14 @@ class alignerUtils(object):
             genome_file, reads_file + '.sai', reads_file
         ])
 
-        cmd_view = ' '.join([
+        cmd_sort = ' '.join([
             'samtools sort',
             '-O bam',
             '-o', bam_loc,
             reads_file + '.sam'
         ])
 
-        command_lines = [cmd_aln, cmd_samse, cmd_view]
+        command_lines = [cmd_aln, cmd_samse, cmd_sort]
 
         # print("BWA COMMAND LINES:", command_lines)
         try:
@@ -316,14 +316,14 @@ class alignerUtils(object):
             reads_file_1, reads_file_2
         ])
 
-        cmd_view = ' '.join([
+        cmd_sort = ' '.join([
             'samtools sort',
             '-O bam',
             '-o', bam_loc,
             reads_file_1 + '.sam'
         ])
 
-        command_lines = [cmd_aln_1, cmd_aln_2, cmd_samse, cmd_view]
+        command_lines = [cmd_aln_1, cmd_aln_2, cmd_samse, cmd_sort]
 
         try:
             for command_line in command_lines:
@@ -366,7 +366,7 @@ class alignerUtils(object):
             genome_file
         ] + reads)
 
-        cmd_view = ' '.join([
+        cmd_sort = ' '.join([
             'samtools sort',
             '-O bam',
             '-o', bam_loc,
@@ -384,12 +384,12 @@ class alignerUtils(object):
             return False
 
         try:
-            logger.info("BWA MEM COMMAND: " + cmd_view)
-            process = subprocess.Popen(cmd_view, shell=True)
+            logger.info("BWA MEM COMMAND: " + cmd_sort)
+            process = subprocess.Popen(cmd_sort, shell=True)
             process.wait()
         except (IOError, OSError) as msg:
             logger.info("I/O error({0}): {1}\n{2}".format(
-                msg.errno, msg.strerror, cmd_view))
+                msg.errno, msg.strerror, cmd_sort))
             return False
 
         os.remove(reads_file_1 + '.sam')

--- a/tool/aligner_utils.py
+++ b/tool/aligner_utils.py
@@ -22,6 +22,7 @@ import os.path
 
 from utils import logger
 from tool.common import cd
+from tool.bam_utils import bamUtils
 
 
 class alignerUtils(object):
@@ -189,8 +190,8 @@ class alignerUtils(object):
         ] + reads)
 
         cmd_view = ' '.join([
-            'samtools view',
-            '-b',
+            'samtools sort',
+            '-O bam',
             '-o', bam_loc,
             reads_file_1 + '.sam'
         ])
@@ -245,8 +246,8 @@ class alignerUtils(object):
         ])
 
         cmd_view = ' '.join([
-            'samtools view',
-            '-b',
+            'samtools sort',
+            '-O bam',
             '-o', bam_loc,
             reads_file + '.sam'
         ])
@@ -303,7 +304,6 @@ class alignerUtils(object):
             genome_file, reads_file_2
         ])
 
-
         cmd_samse = ' '.join([
             'bwa sampe',
             '-f', reads_file_1 + '.sam',
@@ -313,8 +313,8 @@ class alignerUtils(object):
         ])
 
         cmd_view = ' '.join([
-            'samtools view',
-            '-b',
+            'samtools sort',
+            '-O bam',
             '-o', bam_loc,
             reads_file_1 + '.sam'
         ])
@@ -360,8 +360,8 @@ class alignerUtils(object):
         ] + reads)
 
         cmd_view = ' '.join([
-            'samtools view',
-            '-b',
+            'samtools sort',
+            '-O bam',
             '-o', bam_loc,
             reads_file_1 + '.sam'
         ])

--- a/tool/fastq_splitter.py
+++ b/tool/fastq_splitter.py
@@ -89,7 +89,9 @@ class fastq_splitter(Tool):
             DEFAULT = tmp
             Tag used to identify the files. Useful if this is getting run
             manually on a single machine multiple times to prevent collisions of
-            file names
+            file names. It is also the temporary directory used within the
+            compressed out_file containing the separated and compressed FASTQ
+            files.
 
 
         Returns
@@ -158,7 +160,7 @@ class fastq_splitter(Tool):
                 os.remove(out_file)
 
             tar = tarfile.open(output_file_pregz, "w")
-            tar.add("/".join(file_loc_1[:-1]), arcname='tmp')
+            tar.add("/".join(file_loc_1[:-1]), arcname=tag)
             tar.close()
 
             try:
@@ -194,7 +196,9 @@ class fastq_splitter(Tool):
             DEFAULT = tmp
             Tag used to identify the files. Useful if this is getting run
             manually on a single machine multiple times to prevent collisions of
-            file names
+            file names. It is also the temporary directory used within the
+            compressed out_file containing the separated and compressed FASTQ
+            files.
 
 
         Returns
@@ -260,12 +264,12 @@ class fastq_splitter(Tool):
                 file_loc_1 = fqr.fastq1.split("/")
                 new_suffix = "." + str(fqr.output_tag) + "_" + str(fqr.output_file_count) + ".fastq"
                 file_loc_1[-1] = re.sub('.fastq$', new_suffix, file_loc_1[-1])
-                file_loc_1.insert(-1, "tmp")
+                file_loc_1.insert(-1, tag)
 
                 file_loc_2 = fqr.fastq2.split("/")
                 new_suffix = "." + str(fqr.output_tag) + "_" + str(fqr.output_file_count) + ".fastq"
                 file_loc_2[-1] = re.sub('.fastq$', new_suffix, file_loc_2[-1])
-                file_loc_2.insert(-1, "tmp")
+                file_loc_2.insert(-1, tag)
 
                 files_out.append([file_loc_1[-1], file_loc_2[-1]])
 
@@ -294,7 +298,7 @@ class fastq_splitter(Tool):
             if os.path.isfile(out_file):
                 os.remove(out_file)
             tar = tarfile.open(output_file_pregz, "w")
-            tar.add("/".join(file_loc_1[:-1]), arcname='tmp')
+            tar.add("/".join(file_loc_1[:-1]), arcname=tag)
             tar.close()
 
             try:

--- a/tool/fastq_splitter.py
+++ b/tool/fastq_splitter.py
@@ -139,6 +139,14 @@ class fastq_splitter(Tool):
         fqr.closeFastQ()
         fqr.closeOutputFiles()
 
+        fqgz_files = []
+        for fq_file in files_out:
+            command_line = 'pigz ' + "/".join(file_loc_1[:-1]) + '/' + fq_file[0]
+            args = shlex.split(command_line)
+            process = subprocess.Popen(args)
+            process.wait()
+            fqgz_files.append([fq_file[0] + ".gz"])
+
         untar_idx = True
         if "no-untar" in self.configuration and self.configuration["no-untar"] is True:
             untar_idx = False
@@ -148,6 +156,8 @@ class fastq_splitter(Tool):
 
             if os.path.isfile(out_file):
                 os.remove(out_file)
+
+            print("FILE ADDED TO TAR:", "/".join(file_loc_1[:-1]))
             tar = tarfile.open(output_file_pregz, "w")
             tar.add("/".join(file_loc_1[:-1]), arcname='tmp')
             tar.close()
@@ -164,7 +174,7 @@ class fastq_splitter(Tool):
                 process = subprocess.Popen(args)
                 process.wait()
 
-        return files_out
+        return fqgz_files
 
     @task(
         in_file1=FILE_IN, in_file2=FILE_IN, tag=IN,
@@ -262,6 +272,18 @@ class fastq_splitter(Tool):
 
         fqr.closeFastQ()
         fqr.closeOutputFiles()
+
+        fqgz_files = []
+        for fq_file in files_out:
+            command_line = 'pigz ' + "/".join(file_loc_1[:-1]) + '/' + fq_file[0]
+            args = shlex.split(command_line)
+            process = subprocess.Popen(args)
+            process.wait()
+            command_line = 'pigz ' + "/".join(file_loc_1[:-1]) + '/' + fq_file[1]
+            args = shlex.split(command_line)
+            process = subprocess.Popen(args)
+            process.wait()
+            fqgz_files.append([fq_file[0] + ".gz", fq_file[1] + ".gz"])
 
         output_file_pregz = out_file.replace('.tar.gz', '.tar')
 

--- a/tool/fastq_splitter.py
+++ b/tool/fastq_splitter.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import os
 import shlex
 import subprocess
+import shutil
 import sys
 import re
 import tarfile
@@ -185,6 +186,8 @@ class fastq_splitter(Tool):
 
             self._compress_file_mp(output_file_pregz)
 
+            shutil.rmtree("/".join(file_loc_1[:-1]))
+
         return fqgz_files
 
     @task(
@@ -322,6 +325,8 @@ class fastq_splitter(Tool):
             tar.close()
 
             self._compress_file_mp(output_file_pregz)
+
+            shutil.rmtree("/".join(file_loc_1[:-1]))
 
         return fqgz_files
 

--- a/tool/fastq_splitter.py
+++ b/tool/fastq_splitter.py
@@ -157,7 +157,6 @@ class fastq_splitter(Tool):
             if os.path.isfile(out_file):
                 os.remove(out_file)
 
-            print("FILE ADDED TO TAR:", "/".join(file_loc_1[:-1]))
             tar = tarfile.open(output_file_pregz, "w")
             tar.add("/".join(file_loc_1[:-1]), arcname='tmp')
             tar.close()
@@ -310,7 +309,7 @@ class fastq_splitter(Tool):
                 process = subprocess.Popen(args)
                 process.wait()
 
-        return files_out
+        return fqgz_files
 
     def run(self, input_files, input_metadata, output_files):
         """


### PR DESCRIPTION
Introduce changes so that the chunked fastq files are passed around as compressed files. There is also tidying of the tmp directories to reduce data getting left in the COMPSsWorker directory.

Tests have also been updated to remove old files so that there is no conflicts due to running previous tests.