### PR TITLE
Mm bam process by chrom

### DIFF
--- a/docs/adr.rst
+++ b/docs/adr.rst
@@ -36,3 +36,11 @@ The disabling of pylint test for determining if a function should be a static me
 -------------------------------
 
 Based on benchmarking of the pipeline the procedure for merging of bam files has been modified to get an optimal balance between running as much as possible in parallel vs the cost of spinning up new jobs to perform the merging. It was found that running each job merging 10 files provided the break even point between the cost of creating a new job and getting the maximum throughput through the system. It also reduces the number of iterative merge procedures which is beneficial when there are alignments that are difficult to merge.
+
+
+2018-04-26 - BAM Splitting
+--------------------------
+
+Added the required functions for tools to be able to split a bam by the number of chromosomes so that the analysis can be done in parallel. As an initial run this has been implemented in the MACS2 tool, where the indexing of the bam file is performed by the tool. The bam and bai files are passed to the jobs so that they can then extract the chromosome that they are required to analyse.
+
+In the future the creation of the bai file could be done at alignment time, but in the case of MACS2 there is a filtering step on the aligned bam file, so a new index would be required.

--- a/process_chipseq.py
+++ b/process_chipseq.py
@@ -217,8 +217,8 @@ class process_chipseq(Workflow):
             )
 
             try:
-                output_files_generated["filtered_bg"] = b3f_bg_files["filtered_bg"]
-                output_metadata["filtered_bg"] = b3f_bg_meta["filtered_bg"]
+                output_files_generated["filtered_bg"] = b3f_bg_files["bam"]
+                output_metadata["filtered_bg"] = b3f_bg_meta["bam"]
 
                 tool_name = output_metadata['filtered_bg'].meta_data['tool']
                 output_metadata['filtered_bg'].meta_data['tool_description'] = tool_name

--- a/process_chipseq.py
+++ b/process_chipseq.py
@@ -228,12 +228,12 @@ class process_chipseq(Workflow):
 
         # MACS2 to call peaks
         macs_caller = macs2(self.configuration)
-        macs_inputs = {"input": output_files_generated["filtered"]}
-        macs_metadt = {"input": output_metadata['filtered']}
+        macs_inputs = {"bam": output_files_generated["filtered"]}
+        macs_metadt = {"bam": output_metadata['filtered']}
 
         if "bg_loc" in input_files:
-            macs_inputs["background"] = output_files_generated["filtered_bg"]
-            macs_metadt["background"] = output_metadata['filtered_bg']
+            macs_inputs["bam_bg"] = output_files_generated["filtered_bg"]
+            macs_metadt["bam_bg"] = output_metadata['filtered_bg']
 
         m_results_files, m_results_meta = macs_caller.run(
             macs_inputs, macs_metadt,

--- a/process_macs2.py
+++ b/process_macs2.py
@@ -122,12 +122,12 @@ class process_macs2(Workflow):
 
         # MACS2 to call peaks
         macs_caller = macs2(self.configuration)
-        macs_inputs = {"input": input_files["bam"]}
-        macs_metadt = {"input": metadata['bam']}
+        macs_inputs = {"bam": input_files["bam"]}
+        macs_metadt = {"bam": metadata['bam']}
 
         if "bg_loc" in input_files:
-            macs_inputs["background"] = input_files["bam_bg"]
-            macs_metadt["background"] = output_metadata['bam_bg']
+            macs_inputs["bam"] = input_files["bam_bg"]
+            macs_metadt["bam"] = output_metadata['bam_bg']
 
         m_results_files, m_results_meta = macs_caller.run(
             macs_inputs, macs_metadt,

--- a/tests/test_macs2.py
+++ b/tests/test_macs2.py
@@ -31,7 +31,7 @@ def test_macs2():
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
 
     input_files = {
-        "input": resource_path + "macs2.Human.DRR000150.22_aln_filtered.bam"
+        "bam": resource_path + "macs2.Human.DRR000150.22_aln_filtered.bam"
     }
 
     output_files = {
@@ -42,7 +42,7 @@ def test_macs2():
     }
 
     metadata = {
-        "input": Metadata(
+        "bam": Metadata(
             "data_chipseq", "fastq", [], None,
             {'assembly' : 'test'}),
     }
@@ -64,8 +64,8 @@ def test_macs2_background():
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
 
     input_files = {
-        "input": resource_path + "macs2.Human.DRR000150.22_aln_filtered.bam",
-        "background": resource_path + "macs2.Human.DRR000150.22_aln_filtered.bam"
+        "bam": resource_path + "macs2.Human.DRR000150.22_aln_filtered.bam",
+        "bam_bg": resource_path + "macs2.Human.DRR000150.22_aln_filtered.bam"
     }
 
     output_files = {
@@ -76,7 +76,10 @@ def test_macs2_background():
     }
 
     metadata = {
-        "input": Metadata(
+        "bam": Metadata(
+            "data_chipseq", "fastq", [], None,
+            {'assembly' : 'test'}),
+        "bam_bg": Metadata(
             "data_chipseq", "fastq", [], None,
             {'assembly' : 'test'}),
     }

--- a/tool/bam_utils.py
+++ b/tool/bam_utils.py
@@ -17,8 +17,8 @@
 from __future__ import print_function
 import os
 import sys
-import pysam
 import subprocess
+import pysam
 
 from utils import logger
 

--- a/tool/bam_utils.py
+++ b/tool/bam_utils.py
@@ -41,19 +41,12 @@ except ImportError:
 
 class bamUtils(object):
     """
-    Tool for aligning sequence reads to a genome using BWA
+    Tool for handloing bam files
     """
 
     def __init__(self):
         """
         Initialise the tool with its configuration.
-
-
-        Parameters
-        ----------
-        configuration : dict
-            a dictionary containing parameters that define how the operation
-            should be carried out, which are specific to each Tool.
         """
         logger.info("BAM Utils")
 
@@ -134,7 +127,7 @@ class bamUtils(object):
     @staticmethod
     def bam_index(bam_file, bam_idx_file):
         """
-        Wrapper for the pysam SAMtools merge function
+        Wrapper for the pysam SAMtools index function
 
         Parameters
         ----------
@@ -187,9 +180,11 @@ class bamUtils(object):
         bam_file_handle = pysam.AlignmentFile(bam_file, "rb")  # pylint: disable=no-member
         if "SQ" not in bam_file_handle.header:
             return []
-        return [
-            chromosome["SN"] for chromosome in bam_file_handle.header["SQ"]
-        ]
+
+        chromosome_list = [chromosome["SN"] for chromosome in bam_file_handle.header["SQ"]]
+        bam_file_handle.close()
+
+        return chromosome_list
 
     @staticmethod
     def bam_split(bam_file_in, bai_file, chromosome, bam_file_out):  # pylint: disable=unused-argument
@@ -277,14 +272,12 @@ class bamUtils(object):
     @staticmethod
     def check_header(bam_file):
         """
-        Wrapper for the pysam SAMtools merge function
+        Wrapper for the pysam SAMtools for checking if a bam file is sorted
 
         Parameters
         ----------
-        bam_file_1 : str
-            Location of the bam file to merge into
-        bam_file_2 : str
-            Location of the bam file that is to get merged into bam_file_1
+        bool
+            True if the file has been sorted
         """
         output = True
 
@@ -300,7 +293,7 @@ class bamUtils(object):
 class bamUtilsTask(object):
     """
     Wrappers so that the function above can be used as part of a @task within
-    COMPSs avoiding the files being copied around the infrstructure too many
+    COMPSs avoiding the files being copied around the infrastructure too many
     times
     """
 
@@ -528,7 +521,7 @@ class bamUtilsTask(object):
         bam_file_5 : str
             Location of the bam file that is to get merged into bam_file_1
         bam_file_6 : str
-            Location of the bam file to merge into
+            Location of the bam file that is to get merged into bam_file_1
         bam_file_7 : str
             Location of the bam file that is to get merged into bam_file_1
         bam_file_8 : str

--- a/tool/bam_utils.py
+++ b/tool/bam_utils.py
@@ -169,10 +169,10 @@ class bamUtils(object):
             List of the names of the chromosomes that are present in the bam file
         """
         bam_file_handle = pysam.AlignmentFile(bam_file, "rb")  # pylint: disable=no-member
-        if "SN" not in bam_file_handle.header:
+        if "SQ" not in bam_file_handle.header:
             return []
         return [
-            chromosome["SN"] for chromosome in bam_file_handle(bam_file, "rb").header["SQ"]
+            chromosome["SN"] for chromosome in bam_file_handle.header["SQ"]
         ]
 
     @staticmethod
@@ -264,7 +264,7 @@ class bamUtilsTask(object):
         """
         logger.info("BAM @task Utils")
 
-    @task(bam_file=FILE_IN, chromosome_list=OUT)
+    @task(returns=list, bam_file=FILE_IN)
     def bam_list_chromosomes(self, bam_file):  # pylint: disable=no-self-use
         """
         Wrapper to get the list of chromosomes in a given bam file
@@ -280,8 +280,7 @@ class bamUtilsTask(object):
             List of the chromosomes in the bam file
         """
         bam_handle = bamUtils()
-        chromosome_list = bam_handle.bam_list_chromosomes(bam_file)
-        return chromosome_list
+        return bam_handle.bam_list_chromosomes(bam_file)
 
     @task(bam_file=FILE_INOUT)
     def bam_sort(self, bam_file):  # pylint: disable=no-self-use

--- a/tool/bam_utils.py
+++ b/tool/bam_utils.py
@@ -31,7 +31,7 @@ except ImportError:
     logger.warn("[Warning] Cannot import \"pycompss\" API packages.")
     logger.warn("          Using mock decorators.")
 
-    from utils.dummy_pycompss import FILE_IN, FILE_OUT, FILE_INOUT, OUT  # pylint: disable=ungrouped-imports
+    from utils.dummy_pycompss import FILE_IN, FILE_OUT, FILE_INOUT  # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import barrier  # pylint: disable=ungrouped-imports
 

--- a/tool/bam_utils.py
+++ b/tool/bam_utils.py
@@ -143,7 +143,22 @@ class bamUtils(object):
         bam_idx_file : str
             Location of the bam index file (.bai)
         """
-        pysam.index(bam_file, bam_file + "_tmp.bai")  # pylint: disable=no-member
+
+        cmd_view = ' '.join([
+            'samtools index',
+            '-b',
+            bam_file,
+            bam_file + "_tmp.bai"
+        ])
+
+        try:
+            logger.info("INDEX BAM COMMAND: " + cmd_view)
+            process = subprocess.Popen(cmd_view, shell=True)
+            process.wait()
+        except (IOError, OSError) as msg:
+            logger.info("I/O error({0}): {1}\n{2}".format(
+                msg.errno, msg.strerror, cmd_view))
+            return False
 
         try:
             with open(bam_file + "_tmp.bai", "rb") as f_in:

--- a/tool/bam_utils.py
+++ b/tool/bam_utils.py
@@ -195,7 +195,9 @@ class bamUtils(object):
         new_header_sq = [chrom for chrom in new_header["SQ"] if chrom["SN"] == chromosome]
         new_header["SQ"] = new_header_sq
 
-        with pysam.AlignmentFile(bam_file_out, "wb", header=new_header) as out_bam_f:  # pylint: disable=no-member
+        with pysam.AlignmentFile(  # pylint: disable=no-member
+            bam_file_out, "wb", header=new_header, index_filename=bai_file
+        ) as out_bam_f:
             for read in bam_file_handle.fetch(reference=chromosome):
                 out_bam_f.write(read)
 

--- a/tool/bam_utils.py
+++ b/tool/bam_utils.py
@@ -176,7 +176,7 @@ class bamUtils(object):
         ]
 
     @staticmethod
-    def bam_split(bam_file_in, chromosome, bam_file_out):
+    def bam_split(bam_file_in, bai_file, chromosome, bam_file_out):
         """
         Wrapper to extract a single chromosomes worth of reading into a new bam
         file

--- a/tool/bam_utils.py
+++ b/tool/bam_utils.py
@@ -24,7 +24,7 @@ from utils import logger
 try:
     if hasattr(sys, '_run_from_cmdl') is True:
         raise ImportError
-    from pycompss.api.parameter import FILE_IN, FILE_OUT, FILE_INOUT, OUT
+    from pycompss.api.parameter import FILE_IN, FILE_OUT, FILE_INOUT
     from pycompss.api.task import task
     from pycompss.api.api import barrier
 except ImportError:

--- a/tool/bam_utils.py
+++ b/tool/bam_utils.py
@@ -190,14 +190,12 @@ class bamUtils(object):
         bam_file_out : str
             Location of the output bam file
         """
-        bam_file_handle = pysam.AlignmentFile(bam_file_in, "rb")  # pylint: disable=no-member
+        bam_file_handle = pysam.AlignmentFile(bam_file_in, "rb", index_filename=bai_file)  # pylint: disable=no-member
         new_header = bam_file_handle.header
         new_header_sq = [chrom for chrom in new_header["SQ"] if chrom["SN"] == chromosome]
         new_header["SQ"] = new_header_sq
 
-        with pysam.AlignmentFile(  # pylint: disable=no-member
-            bam_file_out, "wb", header=new_header, index_filename=bai_file
-        ) as out_bam_f:
+        with pysam.AlignmentFile(bam_file_out, "wb", header=new_header) as out_bam_f:  # pylint: disable=no-member
             for read in bam_file_handle.fetch(reference=chromosome):
                 out_bam_f.write(read)
 

--- a/tool/bowtie_aligner.py
+++ b/tool/bowtie_aligner.py
@@ -389,6 +389,7 @@ class bowtie2AlignerTool(Tool):
         output_metadata = {}
 
         output_bam_file = output_files["output"]
+        output_bam_file = output_files["bai"]
 
         logger.info("BOWTIE2 ALIGNER: Aligning sequence reads to the genome")
 
@@ -425,6 +426,9 @@ class bowtie2AlignerTool(Tool):
 
         logger.info("Copying bam file into the output file")
         bam_handle.bam_copy(output_bam_list[0], output_bam_file)
+
+        logger.info("Creating output bam index file")
+        bam_handle.bam_index(output_bam_file, output_bai_file)
 
         logger.info("BOWTIE2 ALIGNER: Alignments complete")
 

--- a/tool/bowtie_aligner.py
+++ b/tool/bowtie_aligner.py
@@ -389,7 +389,6 @@ class bowtie2AlignerTool(Tool):
         output_metadata = {}
 
         output_bam_file = output_files["output"]
-        output_bam_file = output_files["bai"]
 
         logger.info("BOWTIE2 ALIGNER: Aligning sequence reads to the genome")
 

--- a/tool/bowtie_aligner.py
+++ b/tool/bowtie_aligner.py
@@ -322,7 +322,7 @@ class bowtie2AlignerTool(Tool):
 
         return command_params
 
-    def run(self, input_files, input_metadata, output_files):
+    def run(self, input_files, input_metadata, output_files):  # pylint: disable=too-many-locals,too-many-statements
         """
         The main function to align bam files to a genome using Bowtie2
 
@@ -426,9 +426,6 @@ class bowtie2AlignerTool(Tool):
 
         logger.info("Copying bam file into the output file")
         bam_handle.bam_copy(output_bam_list[0], output_bam_file)
-
-        logger.info("Creating output bam index file")
-        bam_handle.bam_index(output_bam_file, output_bai_file)
 
         logger.info("BOWTIE2 ALIGNER: Alignments complete")
 

--- a/tool/macs2.py
+++ b/tool/macs2.py
@@ -28,14 +28,14 @@ try:
         raise ImportError
     from pycompss.api.parameter import FILE_IN, FILE_OUT, IN
     from pycompss.api.task import task
-    # from pycompss.api.api import compss_wait_on
+    from pycompss.api.api import compss_open
 except ImportError:
     logger.warn("[Warning] Cannot import \"pycompss\" API packages.")
     logger.warn("          Using mock decorators.")
 
     from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN  # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
-    # from utils.dummy_pycompss import compss_wait_on  # pylint: disable=ungrouped-imports
+    from utils.dummy_pycompss import compss_open  # pylint: disable=ungrouped-imports
 
 from basic_modules.metadata import Metadata
 from basic_modules.tool import Tool
@@ -391,7 +391,45 @@ class macs2(Tool):
                     chromosome)
 
         # Merge the results files into single files.
-
+        with open(output_files['narrow_peak'], 'w') as file_np_handle:
+            with open(output_files['summits'], 'w') as file_s_handle:
+                with open(output_files['broad_peak'], 'w') as file_bp_handle:
+                    with open(output_files['gapped_peak'], 'w') as file_gp_handle:
+                        for chromosome in chr_list:
+                            if hasattr(sys, '_run_from_cmdl') is True:
+                                with open(
+                                    output_files['narrow_peak'] + "." + str(chromosome), 'rb'
+                                ) as file_in_handle:
+                                    file_np_handle.write(file_in_handle.read())
+                                with open(
+                                    output_files['summits'] + "." + str(chromosome), 'rb'
+                                ) as file_in_handle:
+                                    file_s_handle.write(file_in_handle.read())
+                                with open(
+                                    output_files['broad_peak'] + "." + str(chromosome), 'rb'
+                                ) as file_in_handle:
+                                    file_bp_handle.write(file_in_handle.read())
+                                with open(
+                                    output_files['gapped_peak'] + "." + str(chromosome), 'rb'
+                                ) as file_in_handle:
+                                    file_gp_handle.write(file_in_handle.read())
+                            else:
+                                with compss_open(
+                                    output_files['narrow_peak'] + "." + str(chromosome), 'rb'
+                                ) as file_in_handle:
+                                    file_np_handle.write(file_in_handle.read())
+                                with compss_open(
+                                    output_files['summits'] + "." + str(chromosome), 'rb'
+                                ) as file_in_handle:
+                                    file_s_handle.write(file_in_handle.read())
+                                with compss_open(
+                                    output_files['broad_peak'] + "." + str(chromosome), 'rb'
+                                ) as file_in_handle:
+                                    file_bp_handle.write(file_in_handle.read())
+                                with compss_open(
+                                    output_files['gapped_peak'] + "." + str(chromosome), 'rb'
+                                ) as file_in_handle:
+                                    file_gp_handle.write(file_in_handle.read())
 
         output_files_created = {}
         output_metadata = {}

--- a/tool/macs2.py
+++ b/tool/macs2.py
@@ -379,12 +379,12 @@ class macs2(Tool):
         command_params = self.get_macs2_params(self.configuration)
 
         bam_utils_handle = bamUtilsTask()
-        bai_file = bam_utils_handle.bam_index(
+        bam_utils_handle.bam_index(
             input_files['bam'],
             input_files['bam'] + '.bai'
         )
         if 'bam_bg' in input_files:
-            bai_file_bg = bam_utils_handle.bam_index(
+            bam_utils_handle.bam_index(
                 input_files['bam_bg'],
                 input_files['bam_bg'] + '.bai'
             )

--- a/tool/macs2.py
+++ b/tool/macs2.py
@@ -28,14 +28,14 @@ try:
         raise ImportError
     from pycompss.api.parameter import FILE_IN, FILE_OUT, IN
     from pycompss.api.task import task
-    from pycompss.api.api import compss_open
+    from pycompss.api.api import compss_wait_on, compss_open
 except ImportError:
     logger.warn("[Warning] Cannot import \"pycompss\" API packages.")
     logger.warn("          Using mock decorators.")
 
     from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN  # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
-    from utils.dummy_pycompss import compss_open  # pylint: disable=ungrouped-imports
+    from utils.dummy_pycompss import compss_wait_on, compss_open  # pylint: disable=ungrouped-imports
 
 from basic_modules.metadata import Metadata
 from basic_modules.tool import Tool
@@ -114,8 +114,8 @@ class macs2(Tool):
 
         from tool.bam_utils import bamUtils
 
-        bam_tmp_file = bam_file + "." + str(chromosome) + ".bam"
-        bam_bgd_tmp_file = bam_file_bgd + "." + str(chromosome) + ".bam"
+        bam_tmp_file = bam_file.replace(".bam", "." + str(chromosome) + ".bam")
+        bam_bgd_tmp_file = bam_file_bgd.replace(".bam", "." + str(chromosome) + ".bam")
         bam_utils_handle = bamUtils()
         bam_utils_handle.bam_split(bam_file, bai_file, chromosome, bam_tmp_file)
         bam_utils_handle.bam_split(bam_file_bgd, bai_file_bgd, chromosome, bam_bgd_tmp_file)
@@ -228,7 +228,7 @@ class macs2(Tool):
 
         from tool.bam_utils import bamUtils
 
-        bam_tmp_file = bam_file + "." + str(chromosome) + ".bam"
+        bam_tmp_file = bam_file.replace(".bam", "." + str(chromosome) + ".bam")
         bam_utils_handle = bamUtils()
         bam_utils_handle.bam_split(bam_file, bai_file, chromosome, bam_tmp_file)
 
@@ -236,7 +236,10 @@ class macs2(Tool):
         command_line = command_line + ' -n ' + name + '_out --outdir ' + output_dir
 
         logger.info("MACS2 - NAME: " + name)
-        logger.info("Output Files: " + narrowpeak, summits_bed, broadpeak, gappedpeak)
+        logger.info("Output Files: " + narrowpeak)
+        logger.info("Output Files: " + summits_bed)
+        logger.info("Output Files: " + broadpeak)
+        logger.info("Output Files: " + gappedpeak)
         logger.info("MACS2 COMMAND LINE: " + command_line)
 
         if os.path.isfile(bam_tmp_file) is False or os.path.getsize(bam_tmp_file) == 0:
@@ -390,6 +393,7 @@ class macs2(Tool):
             )
 
         chr_list = bam_utils_handle.bam_list_chromosomes(input_files['bam'])
+        chr_list = compss_wait_on(chr_list)
 
         logger.info("MACS2 COMMAND PARAMS: " + ", ".join(command_params))
 

--- a/tool/macs2.py
+++ b/tool/macs2.py
@@ -371,27 +371,27 @@ class macs2(Tool):
 
         logger.info("MACS2 COMMAND PARAMS: " + ", ".join(command_params))
 
-        # handle error
-        if 'background' in input_files:
-            self.macs2_peak_calling(
-                name, str(input_files['input']), str(input_files['background']),
-                command_params,
-                str(output_files['narrow_peak']), str(output_files['summits']),
-                str(output_files['broad_peak']), str(output_files['gapped_peak']),
-                None)
-        else:
-            self.macs2_peak_calling_nobgd(
-                name, str(input_files['input']), command_params,
-                str(output_files['narrow_peak']), str(output_files['summits']),
-                str(output_files['broad_peak']), str(output_files['gapped_peak']),
-                None)
-        # results = compss_wait_on(results)
+        for chromosome in chr_list:
+            if 'background' in input_files:
+                self.macs2_peak_calling(
+                    name, str(input_files['input']), str(input_files['background']),
+                    command_params,
+                    str(output_files['narrow_peak']) + "." + str(chromosome),
+                    str(output_files['summits']) + "." + str(chromosome),
+                    str(output_files['broad_peak']) + "." + str(chromosome),
+                    str(output_files['gapped_peak']) + "." + str(chromosome),
+                    chromosome)
+            else:
+                self.macs2_peak_calling_nobgd(
+                    name, str(input_files['input']), command_params,
+                    str(output_files['narrow_peak']) + "." + str(chromosome),
+                    str(output_files['summits']) + "." + str(chromosome),
+                    str(output_files['broad_peak']) + "." + str(chromosome),
+                    str(output_files['gapped_peak']) + "." + str(chromosome),
+                    chromosome)
 
-        # if results > 0:
-        #     logger.fatal("MACS2 failed with error: {}", results)
-        #     return (
-        #         {}, {}
-        #     )
+        # Merge the results files into single files.
+
 
         output_files_created = {}
         output_metadata = {}

--- a/tool/macs2.py
+++ b/tool/macs2.py
@@ -365,9 +365,7 @@ class macs2(Tool):
         command_params = self.get_macs2_params(self.configuration)
 
         bam_utils_handle = bamUtilsTask()
-        logger.info("BAM FILE: " + input_files['input'])
         chr_list = bam_utils_handle.bam_list_chromosomes(input_files['input'])
-        logger.info("BAM CHROMOSOMES: " + ", ".join(chr_list))
 
         logger.info("MACS2 COMMAND PARAMS: " + ", ".join(command_params))
 


### PR DESCRIPTION
Added the ability for the macs2 tool to split the bam file into bams containing a separate chromosome and then perform the required analysis and then merge back the results into a final file.

In cases where there are large bam files should help improve the throughput. For smaller genomes/bam files there might be a slight performance hit, but minor in comparison to other requirements in the system.