### PR TITLE
Fix gem location

### DIFF
--- a/tool/gem_indexer.py
+++ b/tool/gem_indexer.py
@@ -90,9 +90,10 @@ class gemIndexerTool(Tool):  # pylint: disable=invalid-name
 
         common.zip_file(genome_file + ".gem")
 
-        with open(index_loc, "wb") as f_out:
-            with open(genome_file + ".gem.gz", "rb") as f_in:
-                f_out.write(f_in.read())
+        if genome_file + ".gem.gz" != index_loc:
+            with open(index_loc, "wb") as f_out:
+                with open(genome_file + ".gem.gz", "rb") as f_in:
+                    f_out.write(f_in.read())
 
         return True
 

--- a/tool/gem_indexer.py
+++ b/tool/gem_indexer.py
@@ -90,10 +90,9 @@ class gemIndexerTool(Tool):  # pylint: disable=invalid-name
 
         common.zip_file(genome_file + ".gem")
 
-        if genome_file + ".gem.gz" != index_loc:
-            with open(index_loc, "wb") as f_out:
-                with open(genome_file + ".gem.gz") as f_in:
-                    f_out.write(f_in.read())
+        with open(index_loc, "wb") as f_out:
+            with open(genome_file + ".gem.gz", "rb") as f_in:
+                f_out.write(f_in.read())
 
         return True
 
@@ -119,7 +118,7 @@ class gemIndexerTool(Tool):  # pylint: disable=invalid-name
         # input and output share most metadata
         results = self.gem_indexer(
             input_files['genome'],
-            input_files['genome'] + ".gem.gz"
+            output_files['index']
         )
         results = compss_wait_on(results)
 


### PR DESCRIPTION
Fix so that the GEM index file is placed in the location specified by output_files["index"].

This pull request addresses the issue https://github.com/Multiscale-Genomics/mg-process-fastq/issues/22