### PR TITLE
Config execution

### DIFF
--- a/docs/adr.rst
+++ b/docs/adr.rst
@@ -162,3 +162,9 @@ MACS2 is able to generate a plot of the results as well as a bedGraph. These hav
 ------------------------------------------
 
 IOError was depricated in favour of OSError when moving to py3, but to maintian backwards compatibility IOError also needs to be supported. There were places in the code where this was not true and other places that relied on just OSError. Instances of just IOError have been converted to testing for both IOError and OSError and visa versa.
+
+
+2018-08-15 - Use the config.json execution path
+-----------------------------------------------
+
+Using the directory of the input file for building the location of the working directory with outside of a task is not a viable option as it can write data to the wrong directory. The execution path provided in the config.json arguments is the right place. This location is also the location for output files. This issue occurred as the FASTQ splitter was generating a tar file that the aligners were downloading to the wrong location. Even though this was tidied up this was still not the right place to put this file.

--- a/tests/json/config_biobambam.json
+++ b/tests/json/config_biobambam.json
@@ -9,6 +9,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_bowtie2_paired.json
+++ b/tests/json/config_bowtie2_paired.json
@@ -24,6 +24,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_bowtie2_single.json
+++ b/tests/json/config_bowtie2_single.json
@@ -19,6 +19,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_bsgenome.json
+++ b/tests/json/config_bsgenome.json
@@ -9,6 +9,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_bwa_aln_paired.json
+++ b/tests/json/config_bwa_aln_paired.json
@@ -24,6 +24,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_bwa_aln_single.json
+++ b/tests/json/config_bwa_aln_single.json
@@ -19,6 +19,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_bwa_mem_paired.json
+++ b/tests/json/config_bwa_mem_paired.json
@@ -24,6 +24,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_bwa_mem_single.json
+++ b/tests/json/config_bwa_mem_single.json
@@ -19,6 +19,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_chipseq.json
+++ b/tests/json/config_chipseq.json
@@ -19,6 +19,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_fastqc.json
+++ b/tests/json/config_fastqc.json
@@ -9,6 +9,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_genome_indexer.json
+++ b/tests/json/config_genome_indexer.json
@@ -9,6 +9,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_idamidseq.json
+++ b/tests/json/config_idamidseq.json
@@ -39,6 +39,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_idear.json
+++ b/tests/json/config_idear.json
@@ -29,6 +29,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_inps.json
+++ b/tests/json/config_inps.json
@@ -9,6 +9,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_macs2.json
+++ b/tests/json/config_macs2.json
@@ -9,6 +9,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_mnaseseq.json
+++ b/tests/json/config_mnaseseq.json
@@ -19,6 +19,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_rnaseq.json
+++ b/tests/json/config_rnaseq.json
@@ -19,6 +19,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_tadbit_bin.json
+++ b/tests/json/config_tadbit_bin.json
@@ -8,7 +8,11 @@
         }
     ],
     "arguments": [
-    {
+        {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "/scratch/results/vre/"
         },

--- a/tests/json/config_tadbit_map_parse_filter.json
+++ b/tests/json/config_tadbit_map_parse_filter.json
@@ -24,6 +24,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "/scratch/results/vre/"
         },

--- a/tests/json/config_tadbit_model.json
+++ b/tests/json/config_tadbit_model.json
@@ -8,7 +8,11 @@
         }
     ],
     "arguments": [
-    {
+        {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "/scratch/results/vre/"
         },
@@ -140,7 +144,7 @@
             "required": true,
             "value": "5"
         }
-        
+
     ],
     "output_files": [
     	{

--- a/tests/json/config_tadbit_normalize.json
+++ b/tests/json/config_tadbit_normalize.json
@@ -14,7 +14,11 @@
         }
     ],
     "arguments": [
-    {
+        {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "/scratch/results/vre/"
         },

--- a/tests/json/config_tadbit_segment.json
+++ b/tests/json/config_tadbit_segment.json
@@ -14,7 +14,11 @@
         }
     ],
     "arguments": [
-    {
+        {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "/scratch/results/vre/"
         },

--- a/tests/json/config_trimgalore.json
+++ b/tests/json/config_trimgalore.json
@@ -13,7 +13,11 @@
             "value": "59b7e020d9422a5969b65379"
         }
     ],
-    "arguments": [],
+    "arguments": [
+        {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        }],
     "output_files": [
         {
             "required": true,

--- a/tests/json/config_wgbs.json
+++ b/tests/json/config_wgbs.json
@@ -19,6 +19,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_wgbs_align.json
+++ b/tests/json/config_wgbs_align.json
@@ -24,6 +24,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_wgbs_filter.json
+++ b/tests/json/config_wgbs_filter.json
@@ -14,6 +14,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },
@@ -65,7 +69,7 @@
                 "data_type": "data_wgbs",
                 "compressed": "null"
             }
-        }, 
+        },
         {
             "required": true,
             "allow_multiple": false,
@@ -81,7 +85,7 @@
                 "data_type": "data_wgbs",
                 "compressed": "null"
             }
-        } 
+        }
     ]
 }
 

--- a/tests/json/config_wgbs_index.json
+++ b/tests/json/config_wgbs_index.json
@@ -9,6 +9,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/json/config_wgbs_peak_caller.json
+++ b/tests/json/config_wgbs_peak_caller.json
@@ -24,6 +24,10 @@
     ],
     "arguments": [
         {
+            "name": "execution",
+            "value": "mg_process_fastq/tests/data"
+        },
+        {
             "name": "project",
             "value": "run001"
         },

--- a/tests/test_biobambam.py
+++ b/tests/test_biobambam.py
@@ -45,7 +45,7 @@ def test_biobambam_chipseq():
             {'assembly': 'test'}),
     }
 
-    bbb = biobambam_filter.biobambam()
+    bbb = biobambam_filter.biobambam({"execution": resource_path})
     bbb.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "macs2.Human.DRR000150.22_aln_filtered.bam") is True
@@ -82,7 +82,7 @@ def test_biobambam_idamidseq():
                 {'assembly': 'test'}),
         }
 
-        bbb = biobambam_filter.biobambam()
+        bbb = biobambam_filter.biobambam({"execution": resource_path})
         bbb.run(input_files, metadata, output_files)
 
         assert os.path.isfile(bam_file.replace(".bam", "_filtered.bam")) is True

--- a/tests/test_bowtie2_aligner.py
+++ b/tests/test_bowtie2_aligner.py
@@ -85,7 +85,7 @@ def test_bowtie2_aligner_single():
         )
     }
 
-    bowtie2_handle = bowtie2AlignerTool()
+    bowtie2_handle = bowtie2AlignerTool({"execution": resource_path})
     bowtie2_handle.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "macs2.Human.DRR000150.22_bt2.bam") is True
@@ -145,7 +145,7 @@ def test_bowtie2_aligner_paired():
         )
     }
 
-    bowtie2_handle = bowtie2AlignerTool()
+    bowtie2_handle = bowtie2AlignerTool({"execution": resource_path})
     bowtie2_handle.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "bsSeeker.Mouse.SRR892982_1_bt2.bam") is True

--- a/tests/test_bowtie_indexer.py
+++ b/tests/test_bowtie_indexer.py
@@ -48,7 +48,7 @@ def test_bowtie_indexer_chipseq():
             {'assembly': 'test'}),
     }
 
-    bti = bowtie_indexer.bowtieIndexerTool()
+    bti = bowtie_indexer.bowtieIndexerTool({"execution": resource_path})
     bti.run(input_files, metadata, output_files)
 
     assert os.path.isfile(output_files["index"]) is True
@@ -79,7 +79,7 @@ def test_bowtie_indexer_mnaseseq():
             {'assembly': 'test'}),
     }
 
-    bti = bowtie_indexer.bowtieIndexerTool()
+    bti = bowtie_indexer.bowtieIndexerTool({"execution": resource_path})
     bti.run(input_files, metadata, output_files)
 
     assert os.path.isfile(output_files["index"]) is True
@@ -110,7 +110,7 @@ def test_bowtie_indexer_wgbs():
             {'assembly': 'test'}),
     }
 
-    bti = bowtie_indexer.bowtieIndexerTool()
+    bti = bowtie_indexer.bowtieIndexerTool({"execution": resource_path})
     bti.run(input_files, metadata, output_files)
 
     assert os.path.isfile(output_files["index"]) is True

--- a/tests/test_bs_seeker_aligner.py
+++ b/tests/test_bs_seeker_aligner.py
@@ -60,7 +60,8 @@ def test_bs_seeker_aligner():
     config_param = {
         "aligner" : "bowtie2",
         "aligner_path" : home + "/lib/bowtie2-2.3.4-linux-x86_64",
-        "bss_path" : home + "/lib/BSseeker2"
+        "bss_path" : home + "/lib/BSseeker2",
+        "execution": resource_path
     }
 
     bsa = bs_seeker_aligner.bssAlignerTool(config_param)

--- a/tests/test_bs_seeker_indexer.py
+++ b/tests/test_bs_seeker_indexer.py
@@ -47,7 +47,8 @@ def test_bs_seeker_indexer():
     config_param = {
         "aligner" : "bowtie2",
         "aligner_path" : home + "/lib/bowtie2-2.3.4-linux-x86_64",
-        "bss_path" : home + "/lib/BSseeker2"
+        "bss_path" : home + "/lib/BSseeker2",
+        "execution": resource_path
     }
 
     bsi = bs_seeker_indexer.bssIndexerTool(config_param)

--- a/tests/test_bsgenome.py
+++ b/tests/test_bsgenome.py
@@ -55,6 +55,7 @@ def test_bsgenome():
         "idear_provider": "ENA",
         "idear_release_date": "2013",
         #"idear_circ_chrom": "",
+        "execution": resource_path
     }
 
     bsg_handle = bsgenomeTool(config)

--- a/tests/test_bwa_aligner.py
+++ b/tests/test_bwa_aligner.py
@@ -64,7 +64,7 @@ def test_bwa_aligner_chipseq_aln():
         )
     }
 
-    bwa_t = bwaAlignerTool()
+    bwa_t = bwaAlignerTool({"execution": resource_path})
     bwa_t.run(input_files, metadata, output_files)
 
     print(__file__)
@@ -109,7 +109,7 @@ def test_bwa_aligner_aln():
         )
     }
 
-    bwa_t = bwaAlignerTool()
+    bwa_t = bwaAlignerTool({"execution": resource_path})
     bwa_t.run(input_files, metadata, output_files)
 
     print(__file__)
@@ -170,7 +170,7 @@ def test_bwa_aligner_mem():
         )
     }
 
-    bwa_t = bwaAlignerMEMTool()
+    bwa_t = bwaAlignerMEMTool({"execution": resource_path})
     bwa_t.run(input_files, metadata, output_files)
 
     print(__file__)
@@ -259,7 +259,7 @@ def test_bwa_aligner_aln_paired():
         )
     }
 
-    bwa_t = bwaAlignerTool()
+    bwa_t = bwaAlignerTool({"execution": resource_path})
     bwa_t.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "bsSeeker.Mouse.SRR892982_1_aln.bam") is True
@@ -324,7 +324,7 @@ def test_bwa_aligner_mem_paired():
         )
     }
 
-    bwa_t = bwaAlignerMEMTool()
+    bwa_t = bwaAlignerMEMTool({"execution": resource_path})
     bwa_t.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "bsSeeker.Mouse.SRR892982_1_mem.bam") is True
@@ -400,7 +400,7 @@ def test_bwa_aligner_idamidseq():
             )
         }
 
-        bwa_t = bwaAlignerMEMTool()
+        bwa_t = bwaAlignerMEMTool({"execution": resource_path})
         bwa_t.run(input_files, metadata, output_files)
 
         assert os.path.isfile(fastq_file.replace(".fastq", ".bam")) is True
@@ -444,7 +444,7 @@ def test_bwa_aligner_mnaseseq():
         )
     }
 
-    bwa_t = bwaAlignerTool()
+    bwa_t = bwaAlignerTool({"execution": resource_path})
     bwa_t.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "inps.Mouse.DRR000386.bam") is True

--- a/tests/test_bwa_indexer.py
+++ b/tests/test_bwa_indexer.py
@@ -18,11 +18,12 @@
 from __future__ import print_function
 
 import os.path
-import pytest # pylint: disable=unused-import
+import pytest  # pylint: disable=unused-import
 
 from basic_modules.metadata import Metadata
 
 from tool.bwa_indexer import bwaIndexerTool
+
 
 @pytest.mark.genome
 @pytest.mark.bwa
@@ -45,16 +46,17 @@ def test_bwa_indexer_bwa():
     metadata = {
         "genome": Metadata(
             "Assembly", "fasta", genome_fa, None,
-            {'assembly' : 'test'}),
+            {'assembly': 'test'}),
     }
 
     print(input_files, output_files)
 
-    bwa_it = bwaIndexerTool()
+    bwa_it = bwaIndexerTool({"execution": resource_path})
     bwa_it.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "bsSeeker.Mouse.GRCm38.fasta.bwa.tar.gz") is True
     assert os.path.getsize(resource_path + "bsSeeker.Mouse.GRCm38.fasta.bwa.tar.gz") > 0
+
 
 @pytest.mark.chipseq
 @pytest.mark.genome
@@ -77,16 +79,17 @@ def test_bwa_indexer_chipseq():
     metadata = {
         "genome": Metadata(
             "Assembly", "fasta", genome_fa, None,
-            {'assembly' : 'test'}),
+            {'assembly': 'test'}),
     }
 
     print(input_files, output_files)
 
-    bwa_it = bwaIndexerTool()
+    bwa_it = bwaIndexerTool({"execution": resource_path})
     bwa_it.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "macs2.Human.GCA_000001405.22.fasta.bwa.tar.gz") is True
     assert os.path.getsize(resource_path + "macs2.Human.GCA_000001405.22.fasta.bwa.tar.gz") > 0
+
 
 @pytest.mark.idamidseq
 @pytest.mark.genome
@@ -109,12 +112,12 @@ def test_bwa_indexer_idear():
     metadata = {
         "genome": Metadata(
             "Assembly", "fasta", genome_fa, None,
-            {'assembly' : 'test'}),
+            {'assembly': 'test'}),
     }
 
     print(input_files, output_files)
 
-    bwa_it = bwaIndexerTool()
+    bwa_it = bwaIndexerTool({"execution": resource_path})
     bwa_it.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "idear.Human.GCA_000001405.22.fasta.bwa.tar.gz") is True
@@ -142,12 +145,12 @@ def test_bwa_indexer_mnaseseq():
     metadata = {
         "genome": Metadata(
             "Assembly", "fasta", genome_fa, None,
-            {'assembly' : 'test'}),
+            {'assembly': 'test'}),
     }
 
     print(input_files, output_files)
 
-    bwa_it = bwaIndexerTool()
+    bwa_it = bwaIndexerTool({"execution": resource_path})
     bwa_it.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "inps.Mouse.GRCm38.fasta.bwa.tar.gz") is True

--- a/tests/test_fastq_splitter.py
+++ b/tests/test_fastq_splitter.py
@@ -22,6 +22,7 @@ from basic_modules.metadata import Metadata
 
 from tool.fastq_splitter import fastq_splitter
 
+
 @pytest.mark.wgbs
 def test_paired_splitter():
     """
@@ -34,18 +35,18 @@ def test_paired_splitter():
     fqs_handle = fastq_splitter()
     results = fqs_handle.run(
         {
-            "fastq1" : fastq_1file,
-            "fastq2" : fastq_2file
+            "fastq1": fastq_1file,
+            "fastq2": fastq_2file
         },
         {
             "fastq1": Metadata(
                 "data_rnaseq", "fastq", [], None,
-                {'assembly' : 'test'}),
+                {'assembly': 'test'}),
             "fastq2": Metadata(
                 "data_rnaseq", "fastq", [], None,
-                {'assembly' : 'test'})
+                {'assembly': 'test'})
         },
-        {"output" : fastq_1file + ".tar.gz"}
+        {"output": fastq_1file + ".tar.gz"}
     )
 
     print("WGBS - PAIRED RESULTS:", results)

--- a/tests/test_fastqc_validation.py
+++ b/tests/test_fastqc_validation.py
@@ -18,11 +18,12 @@
 from __future__ import print_function
 
 import os.path
-import pytest # pylint: disable=unused-import
+import pytest  # pylint: disable=unused-import
 
 from basic_modules.metadata import Metadata
 
 from tool.validate_fastqc import fastqcTool
+
 
 @pytest.mark.chipseq
 def test_fastqc_chipseq_0():
@@ -42,7 +43,7 @@ def test_fastqc_chipseq_0():
     metadata = {
         "fastq": Metadata(
             "data_rnaseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -50,6 +51,7 @@ def test_fastqc_chipseq_0():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.hic
 def test_fastqc_hic_0():
@@ -69,7 +71,7 @@ def test_fastqc_hic_0():
     metadata = {
         "fastq": Metadata(
             "data_rnaseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -77,6 +79,7 @@ def test_fastqc_hic_0():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.hic
 def test_fastqc_hic_1():
@@ -96,7 +99,7 @@ def test_fastqc_hic_1():
     metadata = {
         "fastq": Metadata(
             "data_rnaseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -104,6 +107,7 @@ def test_fastqc_hic_1():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.idamidseq
 def test_fastqc_idamseq_0():
@@ -123,7 +127,7 @@ def test_fastqc_idamseq_0():
     metadata = {
         "fastq": Metadata(
             "data_idamseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -131,6 +135,7 @@ def test_fastqc_idamseq_0():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.idamidseq
 def test_fastqc_idamseq_1():
@@ -150,7 +155,7 @@ def test_fastqc_idamseq_1():
     metadata = {
         "fastq": Metadata(
             "data_idamseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -158,6 +163,7 @@ def test_fastqc_idamseq_1():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.idamidseq
 def test_fastqc_idamseq_2():
@@ -177,7 +183,7 @@ def test_fastqc_idamseq_2():
     metadata = {
         "fastq": Metadata(
             "data_idamseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -185,6 +191,7 @@ def test_fastqc_idamseq_2():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.idamidseq
 def test_fastqc_idamseq_3():
@@ -204,7 +211,7 @@ def test_fastqc_idamseq_3():
     metadata = {
         "fastq": Metadata(
             "data_idamseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -212,6 +219,7 @@ def test_fastqc_idamseq_3():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.inps
 def test_fastqc_inps_0():
@@ -231,7 +239,7 @@ def test_fastqc_inps_0():
     metadata = {
         "fastq": Metadata(
             "data_rnaseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -239,6 +247,7 @@ def test_fastqc_inps_0():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.rnaseq
 def test_fastqc_rnaseq_0():
@@ -258,7 +267,7 @@ def test_fastqc_rnaseq_0():
     metadata = {
         "fastq": Metadata(
             "data_rnaseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -266,6 +275,7 @@ def test_fastqc_rnaseq_0():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.rnaseq
 def test_fastqc_rnaseq_1():
@@ -285,7 +295,7 @@ def test_fastqc_rnaseq_1():
     metadata = {
         "fastq": Metadata(
             "data_rnaseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -293,6 +303,7 @@ def test_fastqc_rnaseq_1():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.wgbs
 def test_fastqc_wgbs_0():
@@ -312,7 +323,7 @@ def test_fastqc_wgbs_0():
     metadata = {
         "fastq": Metadata(
             "data_rnaseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()
@@ -320,6 +331,7 @@ def test_fastqc_wgbs_0():
 
     assert os.path.isfile(output_files["report"]) is True
     assert os.path.getsize(output_files["report"]) > 0
+
 
 @pytest.mark.wgbs
 def test_fastqc_wgbs_1():
@@ -339,7 +351,7 @@ def test_fastqc_wgbs_1():
     metadata = {
         "fastq": Metadata(
             "data_rnaseq", "fastq", [], None,
-            {'assembly' : 'test'})
+            {'assembly': 'test'})
     }
 
     fastqc_handle = fastqcTool()

--- a/tests/test_gem_indexer.py
+++ b/tests/test_gem_indexer.py
@@ -51,12 +51,12 @@ def test_gem_indexer():
     metadata = {
         "genome": Metadata(
             "Assembly", "fasta", genome_fa, None,
-            {'assembly' : 'test'}),
+            {'assembly': 'test'}),
     }
 
     print(input_files, output_files)
 
-    gem_it = gemIndexerTool()
+    gem_it = gemIndexerTool({"execution": resource_path})
     gem_it.run(input_files, metadata, output_files)
 
     assert os.path.isfile(genome_gem_idx) is True

--- a/tests/test_idear.py
+++ b/tests/test_idear.py
@@ -16,11 +16,12 @@
 """
 
 import os.path
-import pytest # pylint: disable=unused-import
+import pytest  # pylint: disable=unused-import
 
 from basic_modules.metadata import Metadata
 
 from tool.idear import idearTool
+
 
 @pytest.mark.idamidseq
 def test_idear():
@@ -45,25 +46,26 @@ def test_idear():
     metadata = {
         "bsgenome": Metadata(
             "data_damid_seq", "bsgenome", [], None,
-            {'assembly' : 'test'}, 9606),
+            {'assembly': 'test'}, 9606),
         "bam_1": Metadata(
             "data_damid_seq", "bam", [], None,
-            {'assembly' : 'test'}, 9606),
+            {'assembly': 'test'}, 9606),
         "bam_2": Metadata(
             "data_damid_seq", "bam", [], None,
-            {'assembly' : 'test'}, 9606),
+            {'assembly': 'test'}, 9606),
         "bg_bam_1": Metadata(
             "data_damid_seq", "bam", [], None,
-            {'assembly' : 'test'}, 9606),
+            {'assembly': 'test'}, 9606),
         "bg_bam_2": Metadata(
             "data_damid_seq", "bam", [], None,
-            {'assembly' : 'test'}, 9606),
+            {'assembly': 'test'}, 9606),
     }
 
     config = {
         "idear_common_name": "Human",
         "idear_sample_param": "Nup98",
-        "idear_background_param": "GFP"
+        "idear_background_param": "GFP",
+        "execution": resource_path
     }
 
     idear_handle = idearTool(config)

--- a/tests/test_inps.py
+++ b/tests/test_inps.py
@@ -57,7 +57,7 @@ def test_inps():
         )
     }
 
-    inps_obj = inps.inps()
+    inps_obj = inps.inps({"execution": resource_path})
     inps_files, inps_meta = inps_obj.run(  # pylint: disable=unused-variable
         input_files,
         metadata,

--- a/tests/test_kallisto_indexer.py
+++ b/tests/test_kallisto_indexer.py
@@ -44,7 +44,7 @@ def test_kallisto_indexer():
             {'assembly': 'test'}),
     }
 
-    ki_handle = kallistoIndexerTool()
+    ki_handle = kallistoIndexerTool({"execution": resource_path})
     ki_handle.run(input_files, metadata, output_files)
 
     print(__file__)

--- a/tests/test_kallisto_quant.py
+++ b/tests/test_kallisto_quant.py
@@ -60,7 +60,7 @@ def test_kallisto_quant_paired():
             {'assembly': 'test'}),
     }
 
-    kqft = kallistoQuantificationTool()
+    kqft = kallistoQuantificationTool({"execution": resource_path})
     kqft.run(input_files, metadata, output_files)
 
     assert os.path.isfile(output_files["abundance_h5_file"]) is True
@@ -102,7 +102,7 @@ def test_kallisto_quant_single():
             {'assembly': 'test'}),
     }
 
-    kqft = kallistoQuantificationTool()
+    kqft = kallistoQuantificationTool({"execution": resource_path})
     kqft.run(input_files, metadata, output_files)
 
     assert os.path.isfile(output_files["abundance_h5_file"]) is True

--- a/tests/test_macs2.py
+++ b/tests/test_macs2.py
@@ -48,7 +48,7 @@ def test_macs2():
             {'assembly': 'test'}),
     }
 
-    macs_handle = macs2({"macs_nomodel_param": True})
+    macs_handle = macs2({"macs_nomodel_param": True, "execution": resource_path})
     macs_handle.run(input_files, metadata, output_files)
 
     assert os.path.isfile(resource_path + "macs2.Human.DRR000150.22_peaks.narrowPeak") is True

--- a/tests/test_pipeline_chipseq.py
+++ b/tests/test_pipeline_chipseq.py
@@ -80,7 +80,7 @@ def test_chipseq_pipeline_00():
         'gapped_peak': '/'.join(root_name) + '_filtered_peaks.gappedPeak'
     }
 
-    chipseq_handle = process_chipseq({"macs_nomodel_param": True})
+    chipseq_handle = process_chipseq({"macs_nomodel_param": True, "execution": resource_path})
     chipseq_files, chipseq_meta = chipseq_handle.run(files, metadata, files_out)  # pylint: disable=unused-variable
 
     print(chipseq_files)
@@ -154,7 +154,7 @@ def test_chipseq_pipeline_01():
         'gapped_peak': '/'.join(root_name) + '_filtered_peaks.gappedPeak'
     }
 
-    chipseq_handle = process_chipseq({"macs_nomodel_param": True})
+    chipseq_handle = process_chipseq({"macs_nomodel_param": True, "execution": resource_path})
     chipseq_files, chipseq_meta = chipseq_handle.run(files, metadata, files_out)  # pylint: disable=unused-variable
 
     print(chipseq_files)

--- a/tests/test_pipeline_genome.py
+++ b/tests/test_pipeline_genome.py
@@ -64,7 +64,7 @@ def test_genome_pipeline_00():
         "gem_index": resource_path + 'macs2.Human.GCA_000001405.22.fasta.gem.gz'
     }
 
-    genome_handle = process_genome()
+    genome_handle = process_genome({"execution": resource_path})
     genome_files, genome_meta = genome_handle.run(files, metadata, files_out)  # pylint: disable=unused-variable
 
     print(genome_files)
@@ -122,7 +122,7 @@ def test_genome_pipeline_01():
         except OSError as ose:
             print("Error: %s - %s." % (ose.filename, ose.strerror))
 
-    genome_handle = process_genome()
+    genome_handle = process_genome({"execution": resource_path})
     genome_files, genome_meta = genome_handle.run(files, metadata, files_out)  # pylint: disable=unused-variable
 
     print(genome_files)

--- a/tests/test_pipeline_idamidseq.py
+++ b/tests/test_pipeline_idamidseq.py
@@ -91,6 +91,7 @@ def test_idamidseq_pipeline_00():
         "idear_release_date": "2013",
         "idear_sample_param": "Nup98",
         "idear_background_param": "GFP",
+        "execution": resource_path
     }
 
     files_out = {

--- a/tests/test_pipeline_idear.py
+++ b/tests/test_pipeline_idear.py
@@ -73,6 +73,7 @@ def test_idear_pipeline():
         "idear_release_date": "2013",
         "idear_sample_param": "Nup98",
         "idear_background_param": "GFP",
+        "execution": resource_path
     }
 
     damidseq_handle = process_idear(config_param)

--- a/tests/test_pipeline_mnaseseq.py
+++ b/tests/test_pipeline_mnaseseq.py
@@ -67,7 +67,7 @@ def test_mnaseseq_pipeline():
         'assembly': 'GRCh38'
     }
 
-    mnaseseq_handle = process_mnaseseq()
+    mnaseseq_handle = process_mnaseseq({"execution": resource_path})
     mnaseseq_files, mnaseseq_meta = mnaseseq_handle.run(files, metadata, [])
 
     print(mnaseseq_files, mnaseseq_meta)

--- a/tests/test_pipeline_rnaseq.py
+++ b/tests/test_pipeline_rnaseq.py
@@ -76,7 +76,7 @@ def test_rnaseq_pipeline():
         "run_info_file": 'tests/data/kallisto.run_info.json'
     }
 
-    rs_handle = process_rnaseq()
+    rs_handle = process_rnaseq({"execution": resource_path})
     rs_files, rs_meta = rs_handle.run(files, metadata, files_out)  # pylint: disable=unused-variable
 
     # Checks that the returned files matches the expected set of results

--- a/tests/test_pipeline_tb.py
+++ b/tests/test_pipeline_tb.py
@@ -76,7 +76,7 @@ def test_tb_pipeline():
         'hdf5': True,
     }
 
-    hic_handle = process_hic()
+    hic_handle = process_hic({"execution": resource_path})
     hic_files, hic_meta = hic_handle.run(files, metadata, [])  # pylint: disable=unused-variable
 
     print(hic_files)

--- a/tests/test_pipeline_trimgalore.py
+++ b/tests/test_pipeline_trimgalore.py
@@ -62,7 +62,7 @@ def test_trim_galore_pipeline():
         "fastq1_report": 'tests/data/bsSeeker.Mouse.SRR892982_1.trimmed.single.report.txt'
     }
 
-    tg_handle = process_trim_galore()
+    tg_handle = process_trim_galore({"execution": resource_path})
     tg_files, tg_meta = tg_handle.run(files, metadata, files_out)
 
     # Checks that the returned files matches the expected set of results
@@ -124,7 +124,7 @@ def test_trim_galore_pipeline_02():
         "fastq2_report": 'tests/data/bsSeeker.Mouse.SRR892982_2.trimmed.report.txt'
     }
 
-    tg_handle = process_trim_galore()
+    tg_handle = process_trim_galore({"execution": resource_path})
     tg_files, tg_meta = tg_handle.run(files, metadata, files_out)
 
     # Checks that the returned files matches the expected set of results

--- a/tests/test_pipeline_wgbs.py
+++ b/tests/test_pipeline_wgbs.py
@@ -119,7 +119,8 @@ def test_wgbs_pipeline_01():
         configuration={
             "bss_path": home + "/lib/BSseeker2",
             "aligner": "bowtie2",
-            "aligner_path": home + "/lib/bowtie2-2.3.4-linux-x86_64"
+            "aligner_path": home + "/lib/bowtie2-2.3.4-linux-x86_64",
+            "execution": resource_path
         }
     )
     rs_files, rs_meta = rs_handle.run(files, metadata, files_out)

--- a/tests/test_pipeline_wgbs_index.py
+++ b/tests/test_pipeline_wgbs_index.py
@@ -57,7 +57,8 @@ def test_wgbs_pipeline_index():
         configuration={
             "bss_path": home + "/lib/BSseeker2",
             "aligner": "bowtie2",
-            "aligner_path": home + "/lib/bowtie2-2.3.4-linux-x86_64"
+            "aligner_path": home + "/lib/bowtie2-2.3.4-linux-x86_64",
+            "execution": resource_path
         }
     )
     rs_files, rs_meta = rs_handle.run(files, metadata, files_out)  # pylint: disable=unused-variable

--- a/tests/test_tb_bin.py
+++ b/tests/test_tb_bin.py
@@ -18,9 +18,10 @@
 from __future__ import print_function
 
 import os.path
-import pytest # pylint: disable=unused-import
+import pytest  # pylint: disable=unused-import
 
 from tool.tb_bin import tbBinTool
+
 
 @pytest.mark.hic
 def test_tb_bin():
@@ -28,22 +29,21 @@ def test_tb_bin():
     Test case to bin a sample bam file
     """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
-    
+
     bamin = resource_path + "tb_paired_reads.bam"
     hic_biases = resource_path + "tb_biases_100kb.pickle"
-    
-    files = [bamin,hic_biases]
-        
+
+    files = [bamin, hic_biases]
+
     metadata = {
-        'resolution' : "100000",
-        'norm' : ['raw','norm'],
-        "species" : "Homo sapiens",
-        "assembly" : "Unknown",
-        'ncpus' : 4
+        'resolution': "100000",
+        'norm': ['raw', 'norm'],
+        "species": "Homo sapiens",
+        "assembly": "Unknown",
+        'ncpus': 4
     }
-    
+
     tb = tbBinTool()
     tb_files, tb_meta = tb.run(files, [], metadata)
 
     assert len(tb_files) == 5
-    

--- a/tests/test_tb_filter.py
+++ b/tests/test_tb_filter.py
@@ -39,7 +39,7 @@ def test_tb_filter_frag_01():
         'mapping': ['frag', 'frag']
     }
 
-    tpm = tbFilterTool()
+    tpm = tbFilterTool({"execution": resource_path})
     tpm_files, tpm_meta = tpm.run([reads_tsv], [], metadata)  # pylint: disable=unused-variable
 
     reads_tsv = resource_path + metadata['expt_name'] + "_filtered_map.tsv"
@@ -85,7 +85,7 @@ def test_tb_filter_frag_02():
         'conservative_filtering': True
     }
 
-    tpm = tbFilterTool()
+    tpm = tbFilterTool({"execution": resource_path})
     tpm_files, tpm_meta = tpm.run([reads_tsv], [], metadata)  # pylint: disable=unused-variable
 
     reads_tsv = resource_path + metadata['expt_name'] + "_filtered_map.tsv"
@@ -130,7 +130,7 @@ def test_tb_filter_iter_01():
         'mapping': ['iter', 'iter']
     }
 
-    tpm = tbFilterTool()
+    tpm = tbFilterTool({"execution": resource_path})
     tpm_files, tpm_meta = tpm.run([reads_tsv], [], metadata)  # pylint: disable=unused-variable
 
     reads_tsv = resource_path + metadata['expt_name'] + "_filtered_map.tsv"
@@ -176,7 +176,7 @@ def test_tb_filter_iter_02():
         'conservative_filtering': True
     }
 
-    tpm = tbFilterTool()
+    tpm = tbFilterTool({"execution": resource_path})
     tpm_files, tpm_meta = tpm.run([reads_tsv], [], metadata)  # pylint: disable=unused-variable
 
     reads_tsv = resource_path + metadata['expt_name'] + "_filtered_map.tsv"

--- a/tests/test_tb_full_mapping.py
+++ b/tests/test_tb_full_mapping.py
@@ -19,14 +19,15 @@ from __future__ import print_function
 
 import os.path
 import gzip
-import pytest # pylint: disable=unused-import
+import pytest  # pylint: disable=unused-import
 
 from tool.gem_indexer import gemIndexerTool
 from tool.tb_full_mapping import tbFullMappingTool
 from basic_modules.metadata import Metadata
 
+
 def generate_gem():
-    
+
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
     genome_fa = resource_path + "tb.Human.GCA_000001405.22.fasta"
     genome_gem_fa = resource_path + "tb.Human.GCA_000001405.22_gem.fasta"
@@ -34,7 +35,6 @@ def generate_gem():
     with gzip.open(genome_fa + '.gz', 'rb') as fgz_in:
         with open(genome_fa, 'wb') as f_out:
             f_out.write(fgz_in.read())
-
 
     genome_gem_idx = resource_path + "tb.Human.GCA_000001405.22_gem.fasta.gem.gz"
 
@@ -55,27 +55,27 @@ def generate_gem():
 
     print(input_files, output_files)
 
-    gem_it = gemIndexerTool()
+    gem_it = gemIndexerTool({"execution": resource_path})
     gem_it.run(input_files, metadata, output_files)
 
-    
+
 @pytest.mark.hic
 def test_tb_extract_fastq():
     """
     Extract the compressed FASTQ files
-    """        
+    """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
     fastq_file_1 = resource_path + "tb.Human.SRR1658573_1.fastq"
     fastq_file_2 = resource_path + "tb.Human.SRR1658573_2.fastq"
     gem_file = resource_path + "tb.Human.GCA_000001405.22_gem.fasta.gem"
-    
+
     if not os.path.isfile(gem_file):
         generate_gem()
-    
+
         with gzip.open(gem_file + '.gz', 'rb') as fgz_in:
             with open(gem_file, 'w') as f_out:
                 f_out.write(fgz_in.read())
-            
+
     with gzip.open(fastq_file_1 + '.gz', 'rb') as fgz_in:
         with open(fastq_file_1, 'w') as f_out:
             f_out.write(fgz_in.read())
@@ -88,7 +88,6 @@ def test_tb_extract_fastq():
     assert os.path.getsize(fastq_file_1) > 0
     assert os.path.isfile(fastq_file_2) is True
     assert os.path.getsize(fastq_file_2) > 0
-    
 
 
 @pytest.mark.hic
@@ -99,7 +98,7 @@ def test_tb_full_mapping_frag_01():
     """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
     gem_file = resource_path + "tb.Human.GCA_000001405.22_gem.fasta.gem"
-    
+
     fastq_file_1 = resource_path + "tb.Human.SRR1658573_1.fastq"
 
     files = [
@@ -108,9 +107,9 @@ def test_tb_full_mapping_frag_01():
     ]
 
     metadata = {
-        'assembly' : 'test',
-        'enzyme_name' : 'MboI',
-        'windows' : None
+        'assembly': 'test',
+        'enzyme_name': 'MboI',
+        'windows': None
     }
 
     gem_file = files[1]
@@ -128,6 +127,7 @@ def test_tb_full_mapping_frag_01():
     assert os.path.isfile(map_full) is True
     assert os.path.getsize(map_full) > 0
 
+
 @pytest.mark.hic
 def test_tb_full_mapping_frag_02():
     """
@@ -136,7 +136,7 @@ def test_tb_full_mapping_frag_02():
     """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
     gem_file = resource_path + "tb.Human.GCA_000001405.22_gem.fasta.gem"
-        
+
     fastq_file_2 = resource_path + "tb.Human.SRR1658573_2.fastq"
 
     files = [
@@ -145,9 +145,9 @@ def test_tb_full_mapping_frag_02():
     ]
 
     metadata = {
-        'assembly' : 'test',
-        'enzyme_name' : 'MboI',
-        'windows' : None
+        'assembly': 'test',
+        'enzyme_name': 'MboI',
+        'windows': None
     }
 
     gem_file = files[1]
@@ -165,6 +165,7 @@ def test_tb_full_mapping_frag_02():
     assert os.path.isfile(map_full) is True
     assert os.path.getsize(map_full) > 0
 
+
 @pytest.mark.hic
 def test_tb_full_mapping_iter_01():
     """
@@ -173,7 +174,7 @@ def test_tb_full_mapping_iter_01():
     """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
     gem_file = resource_path + "tb.Human.GCA_000001405.22_gem.fasta.gem"
-        
+
     fastq_file_1 = resource_path + "tb.Human.SRR1658573_1.fastq"
 
     files = [
@@ -182,9 +183,9 @@ def test_tb_full_mapping_iter_01():
     ]
 
     metadata = {
-        'assembly' : 'test',
-        # 'enzyme_name' : 'MboI',
-        'windows' : ((1, 25), (1, 50), (1, 75), (1, 100))
+        'assembly': 'test',
+        # 'enzyme_name': 'MboI',
+        'windows': ((1, 25), (1, 50), (1, 75), (1, 100))
     }
 
     gem_file = files[1]
@@ -208,6 +209,7 @@ def test_tb_full_mapping_iter_01():
     assert os.path.isfile(map100) is True
     assert os.path.getsize(map100) > 0
 
+
 @pytest.mark.hic
 def test_tb_full_mapping_iter_02():
     """
@@ -216,7 +218,7 @@ def test_tb_full_mapping_iter_02():
     """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
     gem_file = resource_path + "tb.Human.GCA_000001405.22_gem.fasta.gem"
-        
+
     fastq_file_2 = resource_path + "tb.Human.SRR1658573_2.fastq"
 
     files = [
@@ -225,9 +227,9 @@ def test_tb_full_mapping_iter_02():
     ]
 
     metadata = {
-        'assembly' : 'test',
-        # 'enzyme_name' : 'MboI',
-        'windows' : ((1, 25), (1, 50), (1, 75), (1, 100))
+        'assembly': 'test',
+        # 'enzyme_name': 'MboI',
+        'windows': ((1, 25), (1, 50), (1, 75), (1, 100))
     }
 
     gem_file = files[1]

--- a/tests/test_tb_generate_tads.py
+++ b/tests/test_tb_generate_tads.py
@@ -107,7 +107,7 @@ def test_tb_generate_tads_iter_01():
 @pytest.mark.hic
 def test_tb_generate_tads_iter_02():
     """
-    Test case to ensure that the BWA indexer works.
+    Test case to ensure that the BWA indexer works.z
     """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
     reads_tsv = resource_path + "tb.Human.SRR1658573_iter_02_filtered_map.tsv"

--- a/tests/test_tb_model.py
+++ b/tests/test_tb_model.py
@@ -18,9 +18,10 @@
 from __future__ import print_function
 
 import os.path
-import pytest # pylint: disable=unused-import
+import pytest  # pylint: disable=unused-import
 
 from tool.tb_model import tbModelTool
+
 
 @pytest.mark.hic
 def test_tb_model():
@@ -28,31 +29,29 @@ def test_tb_model():
     Test case to build a model from a matrix file
     """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
-    
+
     hic_contacts_matrix_norm = resource_path + "tb_nrm_chr21_100kb.abc"
-    
+
     files = [hic_contacts_matrix_norm]
-        
+
     metadata = {
-        'resolution' : "100000",
+        'resolution': "100000",
         'optimize_only': False,
-        'gen_pos_chrom_name' : "chr21",
+        'gen_pos_chrom_name': "chr21",
         'gen_pos_begin': '15400000',
         'gen_pos_end': '20000000',
-        'max_dist':'10000',
-        'upper_bound':'0',
-        'lower_bound':'-0.6',
-        'cutoff':'2',
-        'num_mod_comp':'4',
-        'num_mod_keep':'4',
-        "species" : "Homo sapiens",
-        "assembly" : "Unknown",
-        'ncpus' : 4
+        'max_dist': '10000',
+        'upper_bound': '0',
+        'lower_bound': '-0.6',
+        'cutoff': '2',
+        'num_mod_comp': '4',
+        'num_mod_keep': '4',
+        "species": "Homo sapiens",
+        "assembly": "Unknown",
+        'ncpus': 4
     }
-    
-        
+
     tm = tbModelTool()
     tm_files, tm_meta = tm.run(files, [], metadata)
 
     assert len(tm_files) == 2
-    

--- a/tests/test_tb_normalize.py
+++ b/tests/test_tb_normalize.py
@@ -18,10 +18,11 @@
 from __future__ import print_function
 
 import os.path
-from pysam                                import AlignmentFile
-import pytest # pylint: disable=unused-import
+from pysam import AlignmentFile  # pylint: disable=no-name-in-module
+import pytest  # pylint: disable=unused-import
 
 from tool.tb_normalize import tbNormalizeTool
+
 
 @pytest.mark.hic
 def test_tb_normalize():
@@ -29,23 +30,22 @@ def test_tb_normalize():
     Test case to normalize a sample bam file to 100K
     """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
-    
+
     bamin = resource_path + "tb_paired_reads.bam"
-    
+
     metadata = {
-        'resolution' : "100000",
-        'min_perc' : '2',
-        'max_perc' : '99.8',
-        'ncpus' : '4'
+        'resolution': "100000",
+        'min_perc': '2',
+        'max_perc': '99.8',
+        'ncpus': '4'
     }
-    
+
     bamfile = AlignmentFile(bamin, 'rb')
     if len(bamfile.references) == 1:
         metadata["min_count"] = "10"
     bamfile.close()
-        
+
     tn = tbNormalizeTool()
     tn_files, tn_meta = tn.run([bamin], [], metadata)
 
     assert len(tn_files) > 1
-    

--- a/tests/test_tb_segment.py
+++ b/tests/test_tb_segment.py
@@ -18,9 +18,10 @@
 from __future__ import print_function
 
 import os.path
-import pytest # pylint: disable=unused-import
+import pytest  # pylint: disable=unused-import
 
 from tool.tb_segment import tbSegmentTool
+
 
 @pytest.mark.hic
 def test_tb_segment():
@@ -28,24 +29,23 @@ def test_tb_segment():
     Test case to detect tads and compartments in a sample bam file
     """
     resource_path = os.path.join(os.path.dirname(__file__), "data/")
-    
+
     bamin = resource_path + "tb_paired_reads.bam"
     hic_biases = resource_path + "tb_biases_100kb.pickle"
-    
-    files = [bamin,hic_biases]
-        
+
+    files = [bamin, hic_biases]
+
     metadata = {
-        'resolution' : "100000",
-        'chromosome_names' : 'chr21',
-        "callers" : [
-                "1",
-                "2"
-            ],
-        'ncpus' : 4
+        'resolution': "100000",
+        'chromosome_names': 'chr21',
+        "callers": [
+            "1",
+            "2"
+        ],
+        'ncpus': 4
     }
-    
+
     ts = tbSegmentTool()
     ts_files, ts_meta = ts.run(files, [], metadata)
 
     assert len(ts_files) == 2
-    

--- a/tool/aligner_utils.py
+++ b/tool/aligner_utils.py
@@ -307,14 +307,14 @@ class alignerUtils(object):  # pylint: disable=invalid-name
             'bowtie2',
             '-p 4',
             '-x', genome_file,
+            '-S', reads_file_1 + '.sam',
             ' '.join(params),
         ] + reads)
 
         try:
-            with open(reads_file_1 + '.sam', "w") as f_out:
-                logger.info("BOWTIE2 COMMAND: " + cmd_aln)
-                process = subprocess.Popen(cmd_aln, shell=True, stdout=f_out)
-                process.wait()
+            logger.info("BOWTIE2 COMMAND: " + cmd_aln)
+            process = subprocess.Popen(cmd_aln, shell=True)
+            process.wait()
         except (OSError, IOError) as msg:
             logger.info("I/O error({0}): {1}\n{2}".format(
                 msg.errno, msg.strerror, cmd_aln))

--- a/tool/biobambam_filter.py
+++ b/tool/biobambam_filter.py
@@ -155,11 +155,6 @@ class biobambam(Tool):  # pylint: disable=invalid-name
         logger.info("BIOBAMBAM FILTER: Ready to run")
 
         self.biobambam_filter_alignments(input_files['input'], output_files['output'])
-        # results = compss_wait_on(results)
-
-        # if results is False:
-        #     logger.fatal("BIOBAMBAM: run failed")
-        #     return {}, {}
 
         logger.info("BIOBAMBAM FILTER: completed")
 

--- a/tool/bowtie_aligner.py
+++ b/tool/bowtie_aligner.py
@@ -472,6 +472,8 @@ class bowtie2AlignerTool(Tool):  # pylint: disable=invalid-name
                 output_bam_file_tmp = tmp_fq1 + ".bam"
                 output_bam_list.append(output_bam_file_tmp)
 
+                logger.info("BOWTIE2 ALIGN (PAIRED) FILES:\n\t{}\n\t{}".format(tmp_fq1, tmp_fq2))
+
                 self.bowtie2_aligner_paired(
                     str(input_files["genome"]), tmp_fq1, tmp_fq2,
                     output_bam_file_tmp,
@@ -489,7 +491,7 @@ class bowtie2AlignerTool(Tool):  # pylint: disable=invalid-name
                 output_bam_file_tmp = tmp_fq + ".bam"
                 output_bam_list.append(output_bam_file_tmp)
 
-                logger.info("BOWTIE2 ALN FILES:" + tmp_fq)
+                logger.info("BOWTIE2 ALIGN (SINGLE) FILES:" + tmp_fq)
                 self.bowtie2_aligner_single(
                     str(input_files["genome"]), tmp_fq, output_bam_file_tmp,
                     index_files["1.bt2"],

--- a/tool/bowtie_aligner.py
+++ b/tool/bowtie_aligner.py
@@ -445,8 +445,15 @@ class bowtie2AlignerTool(Tool):  # pylint: disable=invalid-name
             tar = tarfile.open(fastq_file_gz)
             tar.extractall(path=gz_data_path)
             tar.close()
-            os.remove(fastq_file_gz)
             compss_delete_file(fastq_file_gz)
+            try:
+                os.remove(fastq_file_gz)
+            except (OSError, IOError) as msg:
+                logger.warn(
+                    "Unable to remove file I/O error({0}): {1}".format(
+                        msg.errno, msg.strerror
+                    )
+                )
         except tarfile.TarError:
             logger.fatal("Split FASTQ files: Malformed tar file")
             return {}, {}
@@ -516,11 +523,25 @@ class bowtie2AlignerTool(Tool):  # pylint: disable=invalid-name
             for fastq_file_pair in fastq_file_list:
                 tmp_fq = os.path.join(gz_data_path, "tmp", fastq_file_pair[0])
                 compss_delete_file(tmp_fq)
-                os.remove(tmp_fq)
+                try:
+                    os.remove(tmp_fq)
+                except (OSError, IOError) as msg:
+                    logger.warn(
+                        "Unable to remove file I/O error({0}): {1}".format(
+                            msg.errno, msg.strerror
+                        )
+                    )
                 if "fastq2" in input_files:
                     tmp_fq = os.path.join(gz_data_path, "tmp", fastq_file_pair[1])
                     compss_delete_file(tmp_fq)
-                    os.remove(tmp_fq)
+                    try:
+                        os.remove(tmp_fq)
+                    except (OSError, IOError) as msg:
+                        logger.warn(
+                            "Unable to remove file I/O error({0}): {1}".format(
+                                msg.errno, msg.strerror
+                            )
+                        )
 
         tasks_done += 1
         logger.progress("ALIGNER", task_id=tasks_done, total=task_count)

--- a/tool/bowtie_aligner.py
+++ b/tool/bowtie_aligner.py
@@ -408,7 +408,8 @@ class bowtie2AlignerTool(Tool):  # pylint: disable=invalid-name
         sources.append(input_files["loc"])
 
         logger.progress("FASTQ Splitter", task_id=tasks_done, total=task_count)
-        fastq_file_gz = str(fastq1 + ".tar.gz")
+        fastq_file_gz = os.path.join(
+            self.configuration["execution"], os.path.split(fastq1)[1] + ".tar.gz")
         if "fastq2" in input_files:
             fastq2 = input_files["fastq2"]
             sources.append(input_files["fastq2"])

--- a/tool/bs_seeker_aligner.py
+++ b/tool/bs_seeker_aligner.py
@@ -428,7 +428,8 @@ class bssAlignerTool(Tool):  # pylint: disable=invalid-name
 
         logger.progress("FASTQ Splitter", task_id=tasks_done, total=task_count)
 
-        fastq_file_gz = fastq1 + ".tar.gz"
+        fastq_file_gz = os.path.join(
+            self.configuration["execution"], os.path.split(fastq1)[1] + ".tar.gz")
         if "fastq2" in input_files:
             fastq2 = input_files["fastq2"]
             sources.append(input_files["fastq2"])

--- a/tool/bwa_aligner.py
+++ b/tool/bwa_aligner.py
@@ -336,7 +336,8 @@ class bwaAlignerTool(Tool):  # pylint: disable=invalid-name
 
         logger.progress("FASTQ Splitter", task_id=tasks_done, total=task_count)
 
-        fastq_file_gz = str(fastq1 + ".tar.gz")
+        fastq_file_gz = os.path.join(
+            self.configuration["execution"], os.path.split(fastq1)[1] + ".tar.gz")
         if "fastq2" in input_files:
             fastq2 = input_files["fastq2"]
             sources.append(input_files["fastq2"])

--- a/tool/bwa_mem_aligner.py
+++ b/tool/bwa_mem_aligner.py
@@ -376,8 +376,15 @@ class bwaAlignerMEMTool(Tool):  # pylint: disable=invalid-name
             tar = tarfile.open(fastq_file_gz)
             tar.extractall(path=gz_data_path)
             tar.close()
-            os.remove(fastq_file_gz)
             compss_delete_file(fastq_file_gz)
+            try:
+                os.remove(fastq_file_gz)
+            except (OSError, IOError) as msg:
+                logger.warn(
+                    "Unable to remove file I/O error({0}): {1}".format(
+                        msg.errno, msg.strerror
+                    )
+                )
         except tarfile.TarError:
             logger.fatal("Split FASTQ files: Malformed tar file")
             return {}, {}

--- a/tool/bwa_mem_aligner.py
+++ b/tool/bwa_mem_aligner.py
@@ -338,7 +338,8 @@ class bwaAlignerMEMTool(Tool):  # pylint: disable=invalid-name
 
         logger.progress("FASTQ Splitter", task_id=tasks_done, total=task_count)
 
-        fastq_file_gz = str(fastq1 + ".tar.gz")
+        fastq_file_gz = os.path.join(
+            self.configuration["execution"], os.path.split(fastq1)[1] + ".tar.gz")
         if "fastq2" in input_files:
             fastq2 = input_files["fastq2"]
             sources.append(input_files["fastq2"])

--- a/tool/fastqreader.py
+++ b/tool/fastqreader.py
@@ -171,7 +171,7 @@ class fastqreader(object):  # pylint: disable=too-many-instance-attributes,inval
         tag : str
             Tag to identify the output files (DEFAULT: '')
         """
-        if tag != '' and self.output_tag != tag:
+        if tag not in ('', self.output_tag):
             self.output_tag = tag
 
         fq1 = self.fastq1.split("/")

--- a/tool/macs2.py
+++ b/tool/macs2.py
@@ -148,16 +148,22 @@ class macs2(Tool):  # pylint: disable=invalid-name
         if int(bam_utils_handle.bam_count_reads(bam_tmp_file, aligned=True)) > 0:
             try:
                 args = shlex.split(command_line)
-                process = subprocess.Popen(args)
-                process.wait()
+                process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                proc_out, proc_err = process.communicate()
             except (IOError, OSError) as msg:
                 logger.fatal("I/O error({0}): {1}\n{2}".format(
                     msg.errno, msg.strerror, command_line))
                 return False
 
             if process.returncode is not 0:
-                logger.fatal("MACS2 ERROR", process.returncode)
-                return False
+                logger.fatal("MACS2 ERROR: " + str(process.returncode))
+                logger.fatal(
+                    "MACS2 ERROR: BAM counts: " + str(
+                        bam_utils_handle.bam_count_reads(bam_tmp_file, aligned=True)
+                    )
+                )
+                logger.fatal("\n\nMACS2 ERROR - out:\n\t" + str(proc_out))
+                logger.fatal("\n\nMACS2 ERROR - err:\n\t" + str(proc_err))
 
             logger.info('Process Results 1:', process)
 


### PR DESCRIPTION
These changes encompass adding the use of the execution parameter from the VRE for defining the local directory to use of storage for temporary and final output files. The major changes are in the aligners as they extract the split FASTQ files from COMPSs so that they can be extracted and deployed as new jobs for alignment.

There are also changes in all tests to provide the parameter in case the other tools make the change in the future.

The building of file locations within @task methods remains unchanged as when an @task completes the temporary files in that @task are removed by COMPSs.

I have also done some tidying of the test scripts based on pylint and flake8 reports