### PR TITLE
Add keep-dup by default to ChIP-seq pipeline

### DIFF
--- a/docs/adr.rst
+++ b/docs/adr.rst
@@ -162,3 +162,9 @@ MACS2 is able to generate a plot of the results as well as a bedGraph. These hav
 ------------------------------------------
 
 IOError was depricated in favour of OSError when moving to py3, but to maintian backwards compatibility IOError also needs to be supported. There were places in the code where this was not true and other places that relied on just OSError. Instances of just IOError have been converted to testing for both IOError and OSError and visa versa.
+
+
+2018-08-16 - Prevent further duplicate filtering by MACS2
+---------------------------------------------------------
+
+In the process_chipseq.py pipeline the duplicates have already been filtered by BioBamBam2 and samtools so there is no need for further filtering to be done by MACS2.

--- a/process_chipseq.py
+++ b/process_chipseq.py
@@ -244,6 +244,10 @@ class process_chipseq(Workflow):  # pylint: disable=invalid-name,too-few-public-
                 logger.fatal("Background BioBamBam filtering failed")
 
         # MACS2 to call peaks
+        # Duplicates have already been filtered so MACS2 does not need to due
+        # any further filtering
+        self.configuration["macs_keep-dup_param"] = "all"
+
         macs_caller = macs2(self.configuration)
         macs_inputs = {"bam": output_files_generated["filtered"]}
         macs_metadt = {"bam": output_metadata['filtered']}


### PR DESCRIPTION
Added the keep-dup all for MACS2 when run as part of the ChIP-seq pipeline as duplicates have already been filtered out