### PR TITLE
Updates to the run()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ before_cache:
 env:
     matrix:
         - TESTENV=docs
+        - TESTENV=pylint
         - TESTENV=code
         - TESTENV=wgbs_code_1
         - TESTENV=wgbs_code_2
-        - TESTENV=pylint
 
 addons:
     apt:

--- a/docs/adr.rst
+++ b/docs/adr.rst
@@ -185,3 +185,9 @@ Code update to use last features of the development branch of tadbit tools api
 The wrapper of tadbit model was rebuilt to allow the modelling of full genomes, mainly for yeast
 General reshape of all the code according to pylint
 Inclusion of tests for the wrappers and tools of the tadbit pipelines
+
+
+2018-09-17 - Updates to tool and pipline run()
+----------------------------------------------
+
+Changes to the pipelines so that the run() function matches the definitions within the Tool API.

--- a/docs/adr.rst
+++ b/docs/adr.rst
@@ -208,5 +208,5 @@ Macs2 was previously set to work with the BAMPE option for the -f/--format param
 2018-09-17 - Updates to tool and pipline run()
 ----------------------------------------------
 
-Changes to the pipelines so that the run() function matches the definitions within the Tool API.
+Changes to the pipelines so that the run() function matches the definitions within the Tool API. There have also been a number of changes so that the pipeline and tool code is python 3 compatible
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ class Mock(MagicMock):
 
 MOCK_MODULES = [
     'rpy2', 'pyBigWig', 'pycompss', 'pysam',
-    'bs_index', 'bs_index.wg_build', 'FilterReads'
+    'bs_index', 'bs_index.wg_build', 'FilterReads', 'cPickle'
 ]
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 

--- a/scripts/travis/pylint_harness.sh
+++ b/scripts/travis/pylint_harness.sh
@@ -27,7 +27,8 @@ grep -v "\-\-\-\-\-\-\-\-\-" output.err | grep -v "Your code has been rated" | g
 
 if [ -s pylint.err ]
 then
-    cat pylint.err
+    # cat pylint.err
+    cat output.err
     rm pylint.err
     exit 1
 fi

--- a/scripts/travis/pylint_harness.sh
+++ b/scripts/travis/pylint_harness.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-disabled="--disable=similarities,invalid-name,too-many-statements,too-many-arguments,too-many-locals,too-few-public-methods,relative-import,no-self-use"
+disabled="--disable=similarities,invalid-name,too-many-statements,too-many-arguments,too-many-locals,too-few-public-methods,relative-import,no-self-use,,useless-object-inheritance"
 
 pylint ${disabled} --rcfile pylintrc process*.py > output.err
 pylint ${disabled} --rcfile pylintrc *wrapper*.py > output.err

--- a/scripts/travis/pylint_harness.sh
+++ b/scripts/travis/pylint_harness.sh
@@ -18,7 +18,7 @@
 disabled="--disable=similarities,invalid-name,too-many-statements,too-many-arguments,too-many-locals,too-few-public-methods,relative-import,no-self-use,,useless-object-inheritance"
 
 pylint ${disabled} --rcfile pylintrc process*.py > output.err
-pylint ${disabled} --rcfile pylintrc *wrapper*.py > output.err
+pylint ${disabled} --rcfile pylintrc *wrapper*.py >> output.err
 pylint ${disabled} --rcfile pylintrc tool >> output.err
 pylint ${disabled} --rcfile pylintrc tests >> output.err
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'numpy', 'h5py', 'pytest', 'scipy', 'matplotlib==2.2.3', 'pysam', 'mock',
-        'bz2file', 'ConfigParser'
+        'bz2file', 'ConfigParser', 'future'
     ],
     setup_requires=[
         'pytest-runner',

--- a/tadbit_bin_wrapper.py
+++ b/tadbit_bin_wrapper.py
@@ -135,7 +135,7 @@ class tadbit_bin(Workflow): # pylint: disable=invalid-name,too-few-public-method
             )
             input_metadata["species"] = dt_json['scientificName']
         tb_handle = tbBinTool()
-        tb_files, _ = tb_handle.run(in_files, [], input_metadata)
+        tb_files, _ = tb_handle.run(in_files, input_metadata, [])
 
         m_results_files["bin_stats"] = self.configuration['project']+"/bin_stats.tar.gz"
         m_results_files["hic_contacts_matrix_raw"] = self.configuration['project']+"/"+ \
@@ -274,4 +274,3 @@ if __name__ == "__main__":
     IN_ARGS = PARSER.parse_args()
 
     RESULTS = main(IN_ARGS)
-    

--- a/tadbit_bin_wrapper.py
+++ b/tadbit_bin_wrapper.py
@@ -31,17 +31,14 @@ import tarfile
 from random import random
 from string import ascii_letters as letters
 
-# Required for ReadTheDocs
-from functools import wraps  # pylint: disable=unused-import
-
 from utils import logger
 from utils import remap
 
 from basic_modules.workflow import Workflow
 from basic_modules.metadata import Metadata
-from tool.common import CommandLineParser  # pylint: disable=ungrouped-imports
-from tool.common import format_utils  # pylint: disable=ungrouped-imports
 
+from tool.common import CommandLineParser
+from tool.common import format_utils
 from tool.tb_bin import tbBinTool
 
 
@@ -80,7 +77,7 @@ class tadbit_bin(Workflow):  # pylint: disable=invalid-name,too-few-public-metho
         num_cores = multiprocessing.cpu_count()
         self.configuration["ncpus"] = num_cores
 
-        tmp_name = ''.join([letters[int(random()*52)]for _ in xrange(5)])
+        tmp_name = ''.join([letters[int(random()*52)]for _ in range(5)])
         if 'execution' in self.configuration:
             self.configuration['project'] = self.configuration['execution']
         self.configuration['workdir'] = self.configuration['project']+'/_tmp_tadbit_'+tmp_name

--- a/tadbit_bin_wrapper.py
+++ b/tadbit_bin_wrapper.py
@@ -67,7 +67,7 @@ class tadbit_bin(Workflow):  # pylint: disable=invalid-name,too-few-public-metho
             should be carried out, which are specific to each Tool.
         """
         tool_extra_config = json.load(
-            file(os.path.dirname(os.path.abspath(__file__))+'/tadbit_wrappers_config.json')
+            open(os.path.dirname(os.path.abspath(__file__))+'/tadbit_wrappers_config.json')
         )
         os.environ["PATH"] += os.pathsep + format_utils.convert_from_unicode(
             tool_extra_config["bin_path"])

--- a/tadbit_bin_wrapper.py
+++ b/tadbit_bin_wrapper.py
@@ -32,20 +32,22 @@ from random import random
 from string import ascii_letters as letters
 
 # Required for ReadTheDocs
-from functools import wraps # pylint: disable=unused-import
+from functools import wraps  # pylint: disable=unused-import
 
 from utils import logger
 from utils import remap
 
 from basic_modules.workflow import Workflow
 from basic_modules.metadata import Metadata
-from tool.common import CommandLineParser # pylint: disable=ungrouped-imports
-from tool.common import format_utils # pylint: disable=ungrouped-imports
+from tool.common import CommandLineParser  # pylint: disable=ungrouped-imports
+from tool.common import format_utils  # pylint: disable=ungrouped-imports
 
 from tool.tb_bin import tbBinTool
 
+
 # ------------------------------------------------------------------------------
-class tadbit_bin(Workflow): # pylint: disable=invalid-name,too-few-public-methods
+
+class tadbit_bin(Workflow):  # pylint: disable=invalid-name,too-few-public-methods
     """
     Wrapper for the VRE form TADbit bin.
     It extracts a section of a matrix from a BAM file.
@@ -171,7 +173,7 @@ class tadbit_bin(Workflow): # pylint: disable=invalid-name,too-few-public-method
                 "visible": True,
                 "assembly": format_utils.convert_from_unicode(
                     metadata['bamin'].meta_data['assembly']),
-                "norm" : 'raw'
+                "norm": 'raw'
             },
             taxon_id=metadata['bamin'].taxon_id)
         m_results_meta["bin_stats"] = Metadata(
@@ -194,7 +196,7 @@ class tadbit_bin(Workflow): # pylint: disable=invalid-name,too-few-public-method
                     "visible": True,
                     "assembly": format_utils.convert_from_unicode(
                         metadata['bamin'].meta_data['assembly']),
-                    "norm" : 'norm'
+                    "norm": 'norm'
                 },
                 taxon_id=metadata['bamin'].taxon_id)
 
@@ -212,10 +214,11 @@ class tadbit_bin(Workflow): # pylint: disable=invalid-name,too-few-public-method
                 "assembly": input_metadata["assembly"]
             },
             taxon_id=metadata['bamin'].taxon_id)
-        #cleaning
+        # cleaning
         clean_temps(self.configuration['workdir'])
 
         return m_results_files, m_results_meta
+
 
 # ------------------------------------------------------------------------------
 
@@ -232,6 +235,7 @@ def main(args):
                         args.out_metadata)
 
     return result
+
 
 def clean_temps(working_path):
     """Cleans the workspace from temporal folder and scratch files"""
@@ -250,10 +254,11 @@ def clean_temps(working_path):
         pass
     logger.info('[CLEANING] Finished')
 
+
 # ------------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    sys._run_from_cmdl = True # pylint: disable=protected-access
+    sys._run_from_cmdl = True  # pylint: disable=protected-access
 
     # Set up the command line parameters
     PARSER = argparse.ArgumentParser(description="TADbit map")

--- a/tadbit_bin_wrapper.py
+++ b/tadbit_bin_wrapper.py
@@ -25,8 +25,12 @@ import argparse
 import sys
 import json
 import multiprocessing
-import urllib2
 import tarfile
+
+try:
+    from urllib2 import urlopen
+except ImportError:
+    from urllib.request import urlopen
 
 from random import random
 from string import ascii_letters as letters
@@ -127,7 +131,7 @@ class tadbit_bin(Workflow):  # pylint: disable=invalid-name,too-few-public-metho
             input_metadata["assembly"] = metadata['bamin'].meta_data["assembly"]
         if metadata['bamin'].taxon_id:
             dt_json = json.load(
-                urllib2.urlopen(
+                urlopen(
                     "http://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/tax-id/"+
                     str(metadata['bamin'].taxon_id)
                 )

--- a/tadbit_map_parse_filter_wrapper.py
+++ b/tadbit_map_parse_filter_wrapper.py
@@ -45,7 +45,7 @@ if '/opt/COMPSs/Bindings/python' in sys.path:
 
 # ------------------------------------------------------------------------------
 
-class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-public-methods
+class tadbit_map_parse_filter(Workflow):  # pylint: disable=invalid-name,too-few-public-methods
     """
     Wrapper for the VRE form TADbit map, parse and filter.
     It combines different tools to map, merge and filter
@@ -53,7 +53,7 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
     """
     configuration = {}
 
-    def __init__(self, configuration=None): # pylint: disable=too-many-branches
+    def __init__(self, configuration=None):  # pylint: disable=too-many-branches
         """
         Initialise the tool with its configuration.
 
@@ -65,7 +65,7 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
             should be carried out, which are specific to each Tool.
         """
         tool_extra_config = json.load(file(os.path.dirname(os.path.abspath(__file__))
-                                           +'/tadbit_wrappers_config.json'))
+                                           + '/tadbit_wrappers_config.json'))
         if os.path.isdir(format_utils.convert_from_unicode(tool_extra_config["bin_path"])):
             os.environ["PATH"] += os.pathsep + format_utils.convert_from_unicode(
                 tool_extra_config["bin_path"])
@@ -109,7 +109,7 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
         if 'rest_enzyme' not in self.configuration:
             self.configuration["rest_enzyme"] = ''
 
-    def run(self, input_files, metadata, output_files): # pylint: disable=too-many-locals,too-many-statements
+    def run(self, input_files, metadata, output_files):  # pylint: disable=too-many-locals,too-many-statements
         """
         Parameters
         ----------
@@ -137,7 +137,7 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
         if 'parsing:refGenome' in input_files:
             genome_fa = format_utils.convert_from_unicode(input_files['parsing:refGenome'])
         elif 'parsing_refGenome' in self.configuration:
-            genome_fa = self.configuration['public_dir']+ \
+            genome_fa = self.configuration['public_dir'] + \
                 format_utils.convert_from_unicode(self.configuration['parsing_refGenome'])
 
         if 'mapping:refGenome' in input_files:
@@ -145,13 +145,13 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
             assembly = format_utils.convert_from_unicode(
                 metadata['mapping:refGenome'].meta_data['assembly'])
         elif 'mapping_refGenome' in self.configuration:
-            genome_gem = self.configuration['public_dir']+ \
+            genome_gem = self.configuration['public_dir'] + \
                 format_utils.convert_from_unicode(self.configuration['mapping_refGenome'])
             assembly = os.path.basename(genome_gem).split('.')[0]
 
         fastq_file_1 = format_utils.convert_from_unicode(input_files['read1'])
         fastq_file_2 = format_utils.convert_from_unicode(input_files['read2'])
-        input_metadata = remap(self.configuration, "ncpus", "iterative_mapping", \
+        input_metadata = remap(self.configuration, "ncpus", "iterative_mapping",
                                "workdir", "windows", enzyme_name="rest_enzyme")
         input_metadata['quality_plot'] = True
         summary_file = input_metadata["workdir"]+'/'+'summary.txt'
@@ -159,7 +159,7 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
         logger.info("MAPPING")
         logger.info("Read 1 of 2")
         tfm1 = tbFullMappingTool()
-        tfm1_files, tfm1_meta = tfm1.run([genome_gem, fastq_file_1], [], input_metadata)
+        tfm1_files, tfm1_meta = tfm1.run([genome_gem, fastq_file_1], input_metadata, [])
         with open(summary_file, 'w') as outfile:
             outfile.write("Mapping read 1\n--------------\n")
             with open(tfm1_files[-2]) as infile:
@@ -167,7 +167,7 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
 
         logger.info("Read 2 of 2")
         tfm2 = tbFullMappingTool()
-        tfm2_files, tfm2_meta = tfm2.run([genome_gem, fastq_file_2], [], input_metadata)
+        tfm2_files, tfm2_meta = tfm2.run([genome_gem, fastq_file_2], input_metadata, [])
         with open(summary_file, 'a') as outfile:
             outfile.write("\n\nMapping read 2\n--------------\n")
             with open(tfm2_files[-2]) as infile:
@@ -177,14 +177,14 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
         tpm = tbParseMappingTool()
         files = [genome_fa] + tfm1_files[:-2] + tfm2_files[:-2]
 
-        input_metadata = remap(self.configuration, "ncpus", "chromosomes", \
+        input_metadata = remap(self.configuration, "ncpus", "chromosomes",
                                "workdir", enzyme_name="rest_enzyme")
         input_metadata['mapping'] = [tfm1_meta['func'], tfm2_meta['func']]
         input_metadata['expt_name'] = 'vre'
 
         logger.info("TB MAPPED FILES:", files)
         logger.info("TB PARSE METADATA:", input_metadata)
-        tpm_files, tpm_meta = tpm.run(files, [], input_metadata)
+        tpm_files, tpm_meta = tpm.run(files, input_metadata, [])
 
         if 'error' in tpm_meta:
             m_results_meta["paired_reads"] = Metadata(
@@ -225,7 +225,7 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
 
         logger.info("FILTERING")
         tbf = tbFilterTool()
-        tf_files, _ = tbf.run(tpm_files, [], input_metadata)
+        tf_files, _ = tbf.run(tpm_files, input_metadata, [])
         with open(summary_file, 'a') as outfile:
             outfile.write("\n\nFiltering\n--------------\n")
             with open(tf_files[-2]) as infile:
@@ -233,10 +233,9 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
 
         logger.info("TB FILTER FILES:", tf_files[0])
 
-
         m_results_files["paired_reads"] = tf_files[0]+'.bam'
         m_results_files["paired_reads_bai"] = m_results_files["paired_reads"]+'.bai'
-        m_results_files["map_parse_filter_stats"] = self.configuration['project']+ \
+        m_results_files["map_parse_filter_stats"] = self.configuration['project'] + \
             "/map_parse_filter_stats.tar.gz"
 
         with tarfile.open(m_results_files["map_parse_filter_stats"], "w:gz") as tar:
@@ -257,7 +256,7 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
                 "description": "Paired end reads",
                 "visible": True,
                 "assembly": assembly,
-                "paired" : "paired",
+                "paired": "paired",
                 "sorted": "sorted",
                 "associated_files": [
                     m_results_files["paired_reads"]+'.bai'
@@ -290,10 +289,10 @@ class tadbit_map_parse_filter(Workflow): # pylint: disable=invalid-name,too-few-
                 "visible": False
             })
 
-
         clean_temps(self.configuration['workdir'])
 
         return m_results_files, m_results_meta
+
 
 # ------------------------------------------------------------------------------
 
@@ -308,7 +307,6 @@ def main(args):
                         args.in_metadata,
                         args.out_metadata)
 
-
     return result
 
 
@@ -319,7 +317,7 @@ def clean_temps(working_path):
         try:
             if os.path.isfile(file_path):
                 os.unlink(file_path)
-            #elif os.path.isdir(file_path): shutil.rmtree(file_path)
+            # elif os.path.isdir(file_path): shutil.rmtree(file_path)
         except OSError:
             pass
     try:
@@ -328,11 +326,12 @@ def clean_temps(working_path):
         pass
     logger.info('[CLEANING] Finished')
 
+
 # ------------------------------------------------------------------------------
 
 if __name__ == "__main__":
 
-    sys._run_from_cmdl = True # pylint: disable=protected-access
+    sys._run_from_cmdl = True  # pylint: disable=protected-access
 
     # Set up the command line parameters
     PARSER = argparse.ArgumentParser(description="TADbit map")
@@ -341,10 +340,10 @@ if __name__ == "__main__":
                         type=CommandLineParser.valid_file, metavar="config", required=True)
 
     # Metadata
-    PARSER.add_argument("--in_metadata", help="Project metadata", \
+    PARSER.add_argument("--in_metadata", help="Project metadata",
                         metavar="in_metadata", required=True)
     # Output metadata
-    PARSER.add_argument("--out_metadata", help="Output metadata", \
+    PARSER.add_argument("--out_metadata", help="Output metadata",
                         metavar="output_metadata", required=True)
     # Log file
     PARSER.add_argument("--log_file", help="Log file", metavar="log_file", required=True)

--- a/tadbit_map_parse_filter_wrapper.py
+++ b/tadbit_map_parse_filter_wrapper.py
@@ -64,7 +64,7 @@ class tadbit_map_parse_filter(Workflow):  # pylint: disable=invalid-name,too-few
             a dictionary containing parameters that define how the operation
             should be carried out, which are specific to each Tool.
         """
-        tool_extra_config = json.load(file(os.path.dirname(os.path.abspath(__file__))
+        tool_extra_config = json.load(open(os.path.dirname(os.path.abspath(__file__))
                                            + '/tadbit_wrappers_config.json'))
         if os.path.isdir(format_utils.convert_from_unicode(tool_extra_config["bin_path"])):
             os.environ["PATH"] += os.pathsep + format_utils.convert_from_unicode(

--- a/tadbit_map_parse_filter_wrapper.py
+++ b/tadbit_map_parse_filter_wrapper.py
@@ -80,7 +80,7 @@ class tadbit_map_parse_filter(Workflow):  # pylint: disable=invalid-name,too-few
 
         self.configuration["ncpus"] = num_cores
 
-        tmp_name = ''.join([letters[int(random()*52)]for _ in xrange(5)])
+        tmp_name = ''.join([letters[int(random()*52)]for _ in range(5)])
         if 'execution' in self.configuration:
             self.configuration['project'] = self.configuration['execution']
         self.configuration['workdir'] = self.configuration['project']+'/_tmp_tadbit_'+tmp_name

--- a/tadbit_model_wrapper.py
+++ b/tadbit_model_wrapper.py
@@ -72,7 +72,7 @@ class tadbit_model(Workflow):  # pylint: disable=invalid-name,too-few-public-met
             should be carried out, which are specific to each Tool.
         """
 
-        tool_extra_config = json.load(file(os.path.dirname(
+        tool_extra_config = json.load(open(os.path.dirname(
             os.path.abspath(__file__))+'/tadbit_wrappers_config.json'))
         os.environ["PATH"] += os.pathsep + format_utils.convert_from_unicode(
             tool_extra_config["bin_path"])

--- a/tadbit_model_wrapper.py
+++ b/tadbit_model_wrapper.py
@@ -25,8 +25,12 @@ import sys
 import tarfile
 import multiprocessing
 import json
-import urllib2
 import shutil
+
+try:
+    from urllib2 import urlopen
+except ImportError:
+    from urllib.request import urlopen
 
 from random import random
 from string import ascii_letters as letters
@@ -82,7 +86,7 @@ class tadbit_model(Workflow):  # pylint: disable=invalid-name,too-few-public-met
         num_cores = multiprocessing.cpu_count()
         self.configuration["ncpus"] = num_cores
 
-        tmp_name = ''.join([letters[int(random()*52)]for _ in xrange(5)])
+        tmp_name = ''.join([letters[int(random()*52)]for _ in range(5)])
         if 'execution' in self.configuration:
             self.configuration['project'] = self.configuration['execution']
         self.configuration['workdir'] = self.configuration['project']+'/_tmp_tadbit_'+tmp_name
@@ -149,7 +153,7 @@ class tadbit_model(Workflow):  # pylint: disable=invalid-name,too-few-public-met
         if "assembly" in metadata['hic_contacts_matrix_norm'].meta_data:
             input_metadata["assembly"] = metadata['hic_contacts_matrix_norm'].meta_data["assembly"]
         if metadata['hic_contacts_matrix_norm'].taxon_id:
-            dt_json = json.load(urllib2.urlopen(
+            dt_json = json.load(urlopen(
                 "http://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/tax-id/" +
                 str(metadata['hic_contacts_matrix_norm'].taxon_id)))
             input_metadata["species"] = dt_json['scientificName']

--- a/tadbit_model_wrapper.py
+++ b/tadbit_model_wrapper.py
@@ -89,7 +89,7 @@ class tadbit_model(Workflow):  # pylint: disable=invalid-name,too-few-public-met
         if not os.path.exists(self.configuration['workdir']):
             os.makedirs(self.configuration['workdir'])
 
-        self.configuration["optimize_only"] = not "generation:num_mod_comp" in self.configuration
+        self.configuration["optimize_only"] = "generation:num_mod_comp" not in self.configuration
         if "optimization:max_dist" in self.configuration and \
                 not self.configuration["optimize_only"]:
             del self.configuration["optimization:max_dist"]
@@ -150,7 +150,7 @@ class tadbit_model(Workflow):  # pylint: disable=invalid-name,too-few-public-met
             input_metadata["assembly"] = metadata['hic_contacts_matrix_norm'].meta_data["assembly"]
         if metadata['hic_contacts_matrix_norm'].taxon_id:
             dt_json = json.load(urllib2.urlopen(
-                "http://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/tax-id/"+ \
+                "http://www.ebi.ac.uk/ena/data/taxonomy/v1/taxon/tax-id/" +
                 str(metadata['hic_contacts_matrix_norm'].taxon_id)))
             input_metadata["species"] = dt_json['scientificName']
 
@@ -158,7 +158,7 @@ class tadbit_model(Workflow):  # pylint: disable=invalid-name,too-few-public-met
         input_metadata["num_mod_keep"] = self.configuration["num_mod_keep"]
 
         tm_handler = tbModelTool()
-        tm_files, _ = tm_handler.run(in_files, [], input_metadata)
+        tm_files, _ = tm_handler.run(in_files, input_metadata, [])
 
         m_results_files["modeling_stats"] = self.configuration['project']+"/model_stats.tar.gz"
 
@@ -167,7 +167,7 @@ class tadbit_model(Workflow):  # pylint: disable=invalid-name,too-few-public-met
         tar.close()
 
         if not self.configuration["optimize_only"]:
-            m_results_files["tadkit_models"] = self.configuration['project']+"/"+ \
+            m_results_files["tadkit_models"] = self.configuration['project'] + "/" + \
                 os.path.basename(tm_files[1])
             os.rename(tm_files[1], m_results_files["tadkit_models"])
             m_results_meta["tadkit_models"] = Metadata(
@@ -200,6 +200,7 @@ class tadbit_model(Workflow):  # pylint: disable=invalid-name,too-few-public-met
 
         return m_results_files, m_results_meta
 
+
 # ------------------------------------------------------------------------------
 
 def main(args):
@@ -214,6 +215,7 @@ def main(args):
                         args.out_metadata)
 
     return result
+
 
 def clean_temps(working_path):
     """Cleans the workspace from temporal folder and scratch files"""
@@ -232,16 +234,18 @@ def clean_temps(working_path):
         pass
     logger.info('[CLEANING] Finished')
 
+
 def make_absolute_path(files, root):
     """Make paths absolute."""
     for role, path in files.items():
         files[role] = os.path.join(root, path)
     return files
 
+
 # ------------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    sys._run_from_cmdl = True # pylint: disable=protected-access
+    sys._run_from_cmdl = True  # pylint: disable=protected-access
 
     # Set up the command line parameters
     PARSER = argparse.ArgumentParser(description="TADbit map")

--- a/tadbit_normalize_wrapper.py
+++ b/tadbit_normalize_wrapper.py
@@ -79,7 +79,7 @@ class tadbit_normalize(Workflow):  # pylint: disable=invalid-name, too-few-publi
         if "normalization" not in self.configuration:
             self.configuration["normalization"] = "Vanilla"
 
-        tmp_name = ''.join([letters[int(random()*52)]for _ in xrange(5)])
+        tmp_name = ''.join([letters[int(random()*52)]for _ in range(5)])
         if 'execution' in self.configuration:
             self.configuration['project'] = self.configuration['execution']
         self.configuration['workdir'] = self.configuration['project']+'/_tmp_tadbit_'+tmp_name

--- a/tadbit_normalize_wrapper.py
+++ b/tadbit_normalize_wrapper.py
@@ -60,7 +60,7 @@ class tadbit_normalize(Workflow):  # pylint: disable=invalid-name, too-few-publi
             a dictionary containing parameters that define how the operation
             should be carried out, which are specific to each Tool.
         """
-        tool_extra_config = json.load(file(os.path.dirname(
+        tool_extra_config = json.load(open(os.path.dirname(
             os.path.abspath(__file__))+'/tadbit_wrappers_config.json'))
         if os.path.isdir(format_utils.convert_from_unicode(
                 tool_extra_config["bin_path"])):

--- a/tadbit_normalize_wrapper.py
+++ b/tadbit_normalize_wrapper.py
@@ -144,17 +144,17 @@ class tadbit_normalize(Workflow):  # pylint: disable=invalid-name, too-few-publi
         m_results_meta = {}
 
         tn_handler = tbNormalizeTool()
-        tn_files, _ = tn_handler.run([bamin], [], input_metadata)
+        tn_files, _ = tn_handler.run([bamin], input_metadata, [])
 
         m_results_files = {}
         try:
-            m_results_files["hic_biases"] = self.configuration['project']+"/"+\
+            m_results_files["hic_biases"] = self.configuration['project'] + "/" + \
                 os.path.basename(tn_files[0])
             os.rename(tn_files[0], m_results_files["hic_biases"])
         except OSError:
             pass
 
-        m_results_files["normalize_stats"] = self.configuration['project']+"/normalize_stats.tar.gz"
+        m_results_files["normalize_stats"] = self.configuration['project'] + "/normalize_stats.tar.gz"  # pylint: disable=line-too-long
 
         with tarfile.open(m_results_files["normalize_stats"], "w:gz") as tar:
             if len(tn_files) > 1:
@@ -218,7 +218,7 @@ def clean_temps(working_path):
         try:
             if os.path.isfile(file_path):
                 os.unlink(file_path)
-            #elif os.path.isdir(file_path): shutil.rmtree(file_path)
+            # elif os.path.isdir(file_path): shutil.rmtree(file_path)
         except OSError:
             pass
     try:
@@ -231,7 +231,7 @@ def clean_temps(working_path):
 # ------------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    sys._run_from_cmdl = True # pylint: disable=protected-access
+    sys._run_from_cmdl = True  # pylint: disable=protected-access
 
     # Set up the command line parameters
     PARSER = argparse.ArgumentParser(description="TADbit map")

--- a/tadbit_segment_wrapper.py
+++ b/tadbit_segment_wrapper.py
@@ -75,7 +75,7 @@ class tadbit_segment(Workflow):  # pylint: disable=invalid-name, too-few-public-
         num_cores = multiprocessing.cpu_count()
         self.configuration["ncpus"] = num_cores
 
-        tmp_name = ''.join([letters[int(random()*52)]for _ in xrange(5)])
+        tmp_name = ''.join([letters[int(random()*52)]for _ in range(5)])
         if 'execution' in self.configuration:
             self.configuration['project'] = self.configuration['execution']
         self.configuration['workdir'] = self.configuration['project']+'/_tmp_tadbit_'+tmp_name

--- a/tadbit_segment_wrapper.py
+++ b/tadbit_segment_wrapper.py
@@ -61,7 +61,7 @@ class tadbit_segment(Workflow):  # pylint: disable=invalid-name, too-few-public-
             should be carried out, which are specific to each Tool.
         """
 
-        tool_extra_config = json.load(file(os.path.dirname(
+        tool_extra_config = json.load(open(os.path.dirname(
             os.path.abspath(__file__))+'/tadbit_wrappers_config.json'))
         os.environ["PATH"] += os.pathsep + format_utils.convert_from_unicode(
             tool_extra_config["bin_path"])

--- a/tadbit_segment_wrapper.py
+++ b/tadbit_segment_wrapper.py
@@ -42,7 +42,7 @@ from tool.tb_segment import tbSegmentTool
 
 # ------------------------------------------------------------------------------
 
-class tadbit_segment(Workflow): # pylint: disable=invalid-name, too-few-public-methods
+class tadbit_segment(Workflow):  # pylint: disable=invalid-name, too-few-public-methods
     """
     Wrapper for the VRE form TADbit segment.
     It detects TADs and compartments from a BAM file.
@@ -126,9 +126,9 @@ class tadbit_segment(Workflow): # pylint: disable=invalid-name, too-few-public-m
             in_files.append(format_utils.convert_from_unicode(input_files['biases']))
 
         ts_handler = tbSegmentTool()
-        ts_files, _ = ts_handler.run(in_files, [], input_metadata)
+        ts_files, _ = ts_handler.run(in_files, input_metadata, [])
 
-        m_results_files["tads_compartments"] = self.configuration['project']+ \
+        m_results_files["tads_compartments"] = self.configuration['project'] + \
             "/tads_compartments.tar.gz"
 
         tar = tarfile.open(m_results_files["tads_compartments"], "w:gz")

--- a/tests/test_fastq_splitter.py
+++ b/tests/test_fastq_splitter.py
@@ -16,8 +16,8 @@
 """
 
 import os.path
-import pytest
 import gzip
+import pytest
 
 from basic_modules.metadata import Metadata
 

--- a/tests/test_pipeline_trimgalore.py
+++ b/tests/test_pipeline_trimgalore.py
@@ -59,8 +59,12 @@ def test_trim_galore_pipeline():
     }
 
     files_out = {
-        "fastq1_trimmed": 'tests/data/bsSeeker.Mouse.SRR892982_1_trimmed.single.fastq.gz',
-        "fastq1_report": 'tests/data/bsSeeker.Mouse.SRR892982_1.trimmed.single.report.txt'
+        "fastq1_trimmed": os.path.join(
+            resource_path,
+            "bsSeeker.Mouse.SRR892982_1_trimmed.single.fastq.gz"),
+        "fastq1_report": os.path.join(
+            resource_path,
+            "bsSeeker.Mouse.SRR892982_1.trimmed.single.report.txt")
     }
 
     tg_handle = process_trim_galore({"execution": resource_path})

--- a/tool/common.py
+++ b/tool/common.py
@@ -189,6 +189,8 @@ class format_utils(object):
         data : str or collection
             Input object in unicode
         """
+        from past.builtins import basestring  # pylint: disable=redefined-builtin
+
         if isinstance(data, basestring):
             return str(data)
         if isinstance(data, collections.Mapping):

--- a/tool/fastqreader.py
+++ b/tool/fastqreader.py
@@ -94,7 +94,8 @@ class fastqreader(object):  # pylint: disable=too-many-instance-attributes,inval
         """
         if side == 1:
             return self.f1_eof
-        elif side == 2:
+
+        if side == 2:
             return self.f2_eof
 
         logger.error("side has value {}. Permitted values are 1 or 2".format(side))

--- a/tool/fastqreader.py
+++ b/tool/fastqreader.py
@@ -21,6 +21,8 @@ import os
 import errno
 import re
 
+from utils import logger
+
 
 class fastqreader(object):  # pylint: disable=too-many-instance-attributes,invalid-name
     """
@@ -95,6 +97,7 @@ class fastqreader(object):  # pylint: disable=too-many-instance-attributes,inval
         elif side == 2:
             return self.f2_eof
 
+        logger.error("side has value {}. Permitted values are 1 or 2".format(side))
         return "ERROR"
 
     def next(self, side=1):

--- a/tool/forge_bsgenome.py
+++ b/tool/forge_bsgenome.py
@@ -291,9 +291,8 @@ class bsgenomeTool(Tool):  # pylint: disable=invalid-name
                 return False
 
             try:
-                with open(
-                    package_build + "_" + seed_file_param["Version"] + ".tar.gz", "rb"
-                ) as f_in:
+                package_file_name = package_build + "_" + seed_file_param["Version"] + ".tar.gz"
+                with open(package_file_name, "rb") as f_in:
                     with open(bsgenome, "wb") as f_out:
                         f_out.write(f_in.read())
             except (IOError, OSError) as msg:

--- a/tool/macs2.py
+++ b/tool/macs2.py
@@ -174,7 +174,8 @@ class macs2(Tool):  # pylint: disable=invalid-name
         common_handle.to_output_file(output_tmp.format(name, 'peaks.broadPeak'), broadpeak)
         common_handle.to_output_file(output_tmp.format(name, 'peaks.gappedPeak'), gappedpeak)
         common_handle.to_output_file(output_tmp.format(name, 'summits.bed'), summits_bed)
-        common_handle.to_output_file(output_tmp.format(name, 'control_lambda.bdg'), bdg_control_lambda)
+        common_handle.to_output_file(
+            output_tmp.format(name, 'control_lambda.bdg'), bdg_control_lambda)
         common_handle.to_output_file(output_tmp.format(name, 'treat_pileup.bdg'), bdg_treat_pileup)
 
         return True
@@ -376,7 +377,7 @@ class macs2(Tool):  # pylint: disable=invalid-name
 
         return command_params
 
-    def run(self, input_files, input_metadata, output_files):  # pylint: disable=too-many-locals
+    def run(self, input_files, input_metadata, output_files):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         """
         The main function to run MACS 2 for peak calling over a given BAM file
         and matching background BAM file.

--- a/tool/tb_bin.py
+++ b/tool/tb_bin.py
@@ -43,9 +43,9 @@ except ImportError:
 
 from basic_modules.tool import Tool
 
-from pytadbit.parsers.hic_bam_parser import write_matrix  # pylint: disable=import-error
+from pytadbit.parsers.hic_bam_parser import write_matrix  # pylint: disable=import-error,no-name-in-module
 from pytadbit import Chromosome  # pylint: disable=import-error
-from pytadbit.parsers.hic_parser import load_hic_data_from_bam  # pylint: disable=import-error
+from pytadbit.parsers.hic_parser import load_hic_data_from_bam  # pylint: disable=import-error,no-name-in-module
 from pytadbit.mapping.analyze import hic_map  # pylint: disable=import-error
 
 

--- a/tool/tb_bin.py
+++ b/tool/tb_bin.py
@@ -20,14 +20,14 @@ import sys
 from sys import stdout
 from subprocess import PIPE, Popen
 import os
-from cPickle import load
-
-from pytadbit.parsers.hic_bam_parser import write_matrix
-from pytadbit import Chromosome
-from pytadbit.parsers.hic_parser import load_hic_data_from_bam
-from pytadbit.mapping.analyze import hic_map
 
 from utils import logger
+
+try:
+    from cPickle import load
+except ImportError:
+    logger.info("Using pickle instead of cPickle")
+    from pickle import load
 
 try:
     if hasattr(sys, '_run_from_cmdl') is True:
@@ -42,6 +42,11 @@ except ImportError:
     from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
 
 from basic_modules.tool import Tool
+
+from pytadbit.parsers.hic_bam_parser import write_matrix  # pylint: disable=import-error
+from pytadbit import Chromosome  # pylint: disable=import-error
+from pytadbit.parsers.hic_parser import load_hic_data_from_bam  # pylint: disable=import-error
+from pytadbit.mapping.analyze import hic_map  # pylint: disable=import-error
 
 
 # ------------------------------------------------------------------------------

--- a/tool/tb_bin.py
+++ b/tool/tb_bin.py
@@ -227,7 +227,7 @@ class tbBinTool(Tool):  # pylint: disable=invalid-name,too-few-public-methods
 
         return (output_files, output_metadata)
 
-    def run(self, input_files, output_files, metadata=None):  # pylint: disable=too-many-locals
+    def run(self, input_files, input_metadata, output_files):  # pylint: disable=too-many-locals
         """
         The main function to the predict TAD sites for a given resolution from
         the Hi-C matrix
@@ -239,7 +239,7 @@ class tbBinTool(Tool):  # pylint: disable=invalid-name,too-few-public-methods
                 Location of the tadbit bam paired reads
             biases : str
                 Location of the pickle hic biases
-        metadata : dict
+        input_metadata : dict
             resolution : int
                 Resolution of the Hi-C
             coord1 : str
@@ -281,29 +281,29 @@ class tbBinTool(Tool):  # pylint: disable=invalid-name,too-few-public-methods
         if len(input_files) > 1:
             biases = input_files[1]
         resolution = 100000
-        if 'resolution' in metadata:
-            resolution = int(metadata['resolution'])
+        if 'resolution' in input_metadata:
+            resolution = int(input_metadata['resolution'])
 
         coord1 = coord2 = norm = None
         ncpus = 1
-        if 'ncpus' in metadata:
-            ncpus = metadata['ncpus']
+        if 'ncpus' in input_metadata:
+            ncpus = input_metadata['ncpus']
 
-        if 'coord1' in metadata:
-            coord1 = metadata['coord1']
-        if 'coord2' in metadata:
-            coord2 = metadata['coord2']
-        if 'norm' in metadata:
-            norm = metadata['norm']
+        if 'coord1' in input_metadata:
+            coord1 = input_metadata['coord1']
+        if 'coord2' in input_metadata:
+            coord2 = input_metadata['coord2']
+        if 'norm' in input_metadata:
+            norm = input_metadata['norm']
 
         root_name = os.path.dirname(os.path.abspath(bamin))
-        if 'workdir' in metadata:
-            root_name = metadata['workdir']
+        if 'workdir' in input_metadata:
+            root_name = input_metadata['workdir']
 
         # input and output share most metadata
         project_metadata = {}
-        project_metadata["species"] = metadata["species"]
-        project_metadata["assembly"] = metadata["assembly"]
+        project_metadata["species"] = input_metadata["species"]
+        project_metadata["assembly"] = input_metadata["assembly"]
 
         output_files, output_metadata = self.tb_bin(bamin, biases, resolution,
                                                     coord1, coord2, norm, root_name,

--- a/tool/tb_filter.py
+++ b/tool/tb_filter.py
@@ -49,12 +49,17 @@ class tbFilterTool(Tool):  # pylint: disable=invalid-name
     Tool for filtering out experimetnal artifacts from the aligned data
     """
 
-    def __init__(self):
+    def __init__(self, configuration):
         """
         Init function
         """
         logger.info("TADbit filter aligned reads")
         Tool.__init__(self)
+
+        if configuration is None:
+            configuration = {}
+
+        self.configuration.update(configuration)
 
     @task(
         reads=FILE_IN, filter_reads_file=FILE_OUT, custom_filter=IN, conservative=IN,

--- a/tool/tb_filter.py
+++ b/tool/tb_filter.py
@@ -19,10 +19,6 @@ from __future__ import print_function
 import sys
 import os.path
 
-from pytadbit.parsers.hic_bam_parser import bed2D_to_BAMhic
-from pytadbit.mapping.filter import apply_filter, filter_reads
-from pytadbit.mapping.analyze import insert_sizes
-
 from basic_modules.tool import Tool
 
 from utils import logger
@@ -40,6 +36,10 @@ except ImportError:
     from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN  # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import compss_wait_on  # pylint: disable=ungrouped-imports
+
+from pytadbit.parsers.hic_bam_parser import bed2D_to_BAMhic  # pylint: disable=import-error
+from pytadbit.mapping.filter import apply_filter, filter_reads  # pylint: disable=import-error
+from pytadbit.mapping.analyze import insert_sizes  # pylint: disable=import-error
 
 
 # ------------------------------------------------------------------------------

--- a/tool/tb_filter.py
+++ b/tool/tb_filter.py
@@ -49,7 +49,7 @@ class tbFilterTool(Tool):  # pylint: disable=invalid-name
     Tool for filtering out experimetnal artifacts from the aligned data
     """
 
-    def __init__(self, configuration):
+    def __init__(self, configuration=None):
         """
         Init function
         """

--- a/tool/tb_filter.py
+++ b/tool/tb_filter.py
@@ -37,14 +37,14 @@ except ImportError:
     logger.info("[Warning] Cannot import \"pycompss\" API packages.")
     logger.info("          Using mock decorators.")
 
-    from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN # pylint: disable=ungrouped-imports
-    from utils.dummy_pycompss import task # pylint: disable=ungrouped-imports
-    from utils.dummy_pycompss import compss_wait_on # pylint: disable=ungrouped-imports
+    from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN  # pylint: disable=ungrouped-imports
+    from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
+    from utils.dummy_pycompss import compss_wait_on  # pylint: disable=ungrouped-imports
 
 
 # ------------------------------------------------------------------------------
 
-class tbFilterTool(Tool): # pylint: disable=invalid-name
+class tbFilterTool(Tool):  # pylint: disable=invalid-name
     """
     Tool for filtering out experimetnal artifacts from the aligned data
     """
@@ -62,7 +62,7 @@ class tbFilterTool(Tool): # pylint: disable=invalid-name
         output_ed=FILE_OUT, output_or=FILE_OUT, output_rb=FILE_OUT,
         output_sc=FILE_OUT, output_tc=FILE_OUT, output_tl=FILE_OUT,
         output_ts=FILE_OUT, returns=int)
-    def tb_filter( # pylint: disable=too-many-arguments,too-many-locals,too-many-statements,too-many-branches,no-self-use
+    def tb_filter(  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements,too-many-branches,no-self-use
             self, reads, filter_reads_file, custom_filter, min_dist_to_re, min_fragment_size,
             max_fragment_size, conservative, output_de, output_d,
             output_e, output_ed, output_or, output_rb, output_sc, output_tc,
@@ -174,7 +174,7 @@ class tbFilterTool(Tool): # pylint: disable=invalid-name
 
         return masked
 
-    def run(self, input_files, output_files, metadata=None): # pylint: disable=too-many-locals,too-many-statements,unused-argument
+    def run(self, input_files, input_metadata, output_files):  # pylint: disable=too-many-locals,too-many-statements,unused-argument
         """
         The main function to filter the reads to remove experimental artifacts
 
@@ -202,26 +202,26 @@ class tbFilterTool(Tool): # pylint: disable=invalid-name
 
         conservative = True
         custom_filter = None
-        if 'custom_filter' in metadata:
-            custom_filter = metadata['filters']
+        if 'custom_filter' in input_metadata:
+            custom_filter = input_metadata['filters']
 
-        elif 'conservative' in metadata:
-            conservative = metadata['conservative']
+        elif 'conservative' in input_metadata:
+            conservative = input_metadata['conservative']
 
         min_dist_to_re = 915
         max_fragment_size = 100000
         min_fragment_size = 100
-        if 'min_dist_RE' in metadata:
-            min_dist_to_re = int(metadata['min_dist_RE'])
-        if 'min_fragment_size' in metadata:
-            min_fragment_size = int(metadata['min_fragment_size'])
-        if 'max_fragment_size' in metadata:
-            max_fragment_size = int(metadata['max_fragment_size'])
+        if 'min_dist_RE' in input_metadata:
+            min_dist_to_re = int(input_metadata['min_dist_RE'])
+        if 'min_fragment_size' in input_metadata:
+            min_fragment_size = int(input_metadata['min_fragment_size'])
+        if 'max_fragment_size' in input_metadata:
+            max_fragment_size = int(input_metadata['max_fragment_size'])
 
         root_name = reads.split("/")
 
         filtered_reads_file = "/".join(root_name[0:-1]) + '/' + \
-            metadata['expt_name'] + '_filtered_map.tsv'
+            input_metadata['expt_name'] + '_filtered_map.tsv'
 
         output_de = filtered_reads_file + '_dangling-end.tsv'
         output_d = filtered_reads_file + '_duplicated.tsv'
@@ -245,13 +245,13 @@ class tbFilterTool(Tool): # pylint: disable=invalid-name
             output_sc, output_tc, output_tl, output_ts)
         results = compss_wait_on(results)
 
-        if 'outbam' in metadata:
-            outbam = metadata['root_dir'] + '/' + metadata['outbam']
+        if 'outbam' in input_metadata:
+            outbam = input_metadata['root_dir'] + '/' + input_metadata['outbam']
             bed2D_to_BAMhic(filtered_reads_file, True, 32, outbam, 'mid', results)
             filtered_reads_file = outbam
 
         hist_path = ''
-        if 'histogram' in metadata:
+        if 'histogram' in input_metadata:
             hist_path = "/".join(root_name[0:-1]) + '/histogram_fragment_sizes_.png'
             log_path = "/".join(root_name[0:-1]) + '/filter_log.txt'
 
@@ -263,7 +263,7 @@ class tbFilterTool(Tool): # pylint: disable=invalid-name
             f_handler = open(log_path, "w")
             sys.stdout = f_handler
 
-            #insert size
+            # insert size
             logger.info('Insert size\n')
 
             logger.info('  - median insert size = {0}'.format(median))
@@ -271,8 +271,8 @@ class tbFilterTool(Tool): # pylint: disable=invalid-name
             logger.info('  - max insert size (when a gap in continuity of > 10 bp \
                 is found in fragment lengths) = {0}'.format(max_f))
 
-            max_mole = max_f # pseudo DEs
-            min_dist = max_f + mad # random breaks
+            max_mole = max_f  # pseudo DEs
+            min_dist = max_f + mad  # random breaks
             logger.info('   Using the maximum continuous fragment size'
                         '('+str(max_mole)+' bp) to check '
                         'for pseudo-dangling ends')
@@ -283,7 +283,7 @@ class tbFilterTool(Tool): # pylint: disable=invalid-name
             f_handler.close()
 
         return_files = [filtered_reads_file]
-        if 'histogram' in metadata:
+        if 'histogram' in input_metadata:
             return_files += [log_path, hist_path]
         return (return_files, output_metadata)
 

--- a/tool/tb_filter.py
+++ b/tool/tb_filter.py
@@ -37,7 +37,7 @@ except ImportError:
     from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import compss_wait_on  # pylint: disable=ungrouped-imports
 
-from pytadbit.parsers.hic_bam_parser import bed2D_to_BAMhic  # pylint: disable=import-error
+from pytadbit.parsers.hic_bam_parser import bed2D_to_BAMhic  # pylint: disable=import-error,no-name-in-module
 from pytadbit.mapping.filter import apply_filter, filter_reads  # pylint: disable=import-error
 from pytadbit.mapping.analyze import insert_sizes  # pylint: disable=import-error
 

--- a/tool/tb_full_mapping.py
+++ b/tool/tb_full_mapping.py
@@ -18,7 +18,10 @@
 from __future__ import print_function
 import sys
 
-from os import path, unlink
+from os import path
+from os import unlink
+
+from past.builtins import basestring  # pylint: disable=redefined-builtin
 
 from basic_modules.tool import Tool
 

--- a/tool/tb_full_mapping.py
+++ b/tool/tb_full_mapping.py
@@ -20,9 +20,6 @@ import sys
 
 from os import path, unlink
 
-from pytadbit.mapping.mapper import full_mapping
-from pytadbit.utils.fastq_utils import quality_plot
-
 from basic_modules.tool import Tool
 
 from utils import logger
@@ -42,6 +39,9 @@ except ImportError:
     from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
     # from utils.dummy_pycompss import constraint # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import compss_wait_on  # pylint: disable=ungrouped-imports
+
+from pytadbit.mapping.mapper import full_mapping  # pylint: disable=import-error
+from pytadbit.utils.fastq_utils import quality_plot  # pylint: disable=import-error
 
 
 # ------------------------------------------------------------------------------

--- a/tool/tb_full_mapping.py
+++ b/tool/tb_full_mapping.py
@@ -218,7 +218,7 @@ class tbFullMappingTool(Tool):  # pylint: disable=invalid-name
             input_metadata['ncpus'] = 8
         if 'iterative_mapping' in input_metadata:
             if isinstance(input_metadata['iterative_mapping'], basestring):
-                frag_base = not input_metadata['iterative_mapping'].lower() in ("yes", "true", "t", "1")
+                frag_base = not input_metadata['iterative_mapping'].lower() in ("yes", "true", "t", "1")  # pylint: disable=line-too-long
             else:
                 frag_base = not input_metadata['iterative_mapping']
         else:

--- a/tool/tb_model.py
+++ b/tool/tb_model.py
@@ -36,14 +36,15 @@ except ImportError:
     logger.info("[Warning] Cannot import \"pycompss\" API packages.")
     logger.info("          Using mock decorators.")
 
-    from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN # pylint: disable=ungrouped-imports
-    from utils.dummy_pycompss import task # pylint: disable=ungrouped-imports
-    #from utils.dummy_pycompss import compss_wait_on # pylint: disable=ungrouped-imports
-    #from utils.dummy_pycompss import constraint
+    from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN  # pylint: disable=ungrouped-imports
+    from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
+    # from utils.dummy_pycompss import compss_wait_on  # pylint: disable=ungrouped-imports
+    # from utils.dummy_pycompss import constraint
 
 # ------------------------------------------------------------------------------
 
-class tbModelTool(Tool): # pylint: disable=invalid-name
+
+class tbModelTool(Tool):  # pylint: disable=invalid-name
     """
     Tool for normalizing an adjacency matrix
     """
@@ -59,7 +60,7 @@ class tbModelTool(Tool): # pylint: disable=invalid-name
           gen_pos_begin=IN, gen_pos_end=IN, num_mod_comp=IN, num_mod_keep=IN,
           max_dist=IN, upper_bound=IN, lower_bound=IN, cutoff=IN, workdir=IN,
           model_dir=FILE_OUT)
-    def tb_model(self, optimize_only, hic_contacts_matrix_norm, resolution, # pylint: disable=too-many-locals,too-many-statements,unused-argument,no-self-use,too-many-arguments
+    def tb_model(self, optimize_only, hic_contacts_matrix_norm, resolution,  # pylint: disable=too-many-locals,too-many-statements,unused-argument,no-self-use,too-many-arguments
                  gen_pos_chrom_name, gen_pos_begin,
                  gen_pos_end, num_mod_comp, num_mod_keep,
                  max_dist, upper_bound, lower_bound, cutoff, workdir, metadata,
@@ -114,7 +115,7 @@ class tbModelTool(Tool): # pylint: disable=invalid-name
             Location of the folder with the modeling files and stats
 
         """
-        #chr_hic_data = read_matrix(matrix_file, resolution=int(resolution))
+        # chr_hic_data = read_matrix(matrix_file, resolution=int(resolution))
 
         logger.info("TB MODELING: {0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10},{11}".format(
             hic_contacts_matrix_norm,
@@ -140,7 +141,7 @@ class tbModelTool(Tool): # pylint: disable=invalid-name
         if not os.path.exists(os.path.join(workdir, name)):
             os.makedirs(os.path.join(workdir, name))
 
-        #=======================================================================
+        # =======================================================================
         # _cmd = [
         #     'model_and_analyze.py',
         #     '--norm', hic_contacts_matrix_norm,
@@ -182,7 +183,7 @@ class tbModelTool(Tool): # pylint: disable=invalid-name
         #     _cmd.append(str(num_mod_keep))
         #     _cmd.append('--outdir')
         #     _cmd.append(workdir)
-        #=======================================================================
+        # =======================================================================
 
         _cmd = [
             'tadbit', 'model',
@@ -238,7 +239,7 @@ class tbModelTool(Tool): # pylint: disable=invalid-name
 
         return (output_files, output_metadata)
 
-    def run(self, input_files, output_files, metadata=None): # pylint: disable=too-many-locals
+    def run(self, input_files, input_metadata, output_files):  # pylint: disable=too-many-locals
         """
         The main function for the normalization of the Hi-C matrix to a given resolution
 
@@ -294,29 +295,29 @@ class tbModelTool(Tool): # pylint: disable=invalid-name
         hic_contacts_matrix_norm = input_files[0]
 
         ncpus = 1
-        if 'ncpus' in metadata:
-            ncpus = metadata['ncpus']
+        if 'ncpus' in input_metadata:
+            ncpus = input_metadata['ncpus']
 
-        optimize_only = metadata["optimize_only"]
-        gen_pos_chrom_name = metadata['gen_pos_chrom_name']
-        resolution = metadata['resolution']
-        gen_pos_begin = metadata['gen_pos_begin']
-        gen_pos_end = metadata['gen_pos_end']
-        num_mod_comp = metadata['num_mod_comp']
-        num_mod_keep = metadata['num_mod_keep']
-        max_dist = metadata['max_dist']
-        upper_bound = metadata['upper_bound']
-        lower_bound = metadata['lower_bound']
-        cutoff = metadata['cutoff']
+        optimize_only = input_metadata["optimize_only"]
+        gen_pos_chrom_name = input_metadata['gen_pos_chrom_name']
+        resolution = input_metadata['resolution']
+        gen_pos_begin = input_metadata['gen_pos_begin']
+        gen_pos_end = input_metadata['gen_pos_end']
+        num_mod_comp = input_metadata['num_mod_comp']
+        num_mod_keep = input_metadata['num_mod_keep']
+        max_dist = input_metadata['max_dist']
+        upper_bound = input_metadata['upper_bound']
+        lower_bound = input_metadata['lower_bound']
+        cutoff = input_metadata['cutoff']
 
         root_name = os.path.dirname(os.path.abspath(hic_contacts_matrix_norm))
-        if 'workdir' in metadata:
-            root_name = metadata['workdir']
+        if 'workdir' in input_metadata:
+            root_name = input_metadata['workdir']
 
         project_metadata = {}
-        project_metadata["species"] = metadata["species"]
-        project_metadata["assembly"] = metadata["assembly"]
-        project_metadata["project"] = os.path.basename(os.path.normpath(metadata["project"]))
+        project_metadata["species"] = input_metadata["species"]
+        project_metadata["assembly"] = input_metadata["assembly"]
+        project_metadata["project"] = os.path.basename(os.path.normpath(input_metadata["project"]))
 
         # input and output share most metadata
 

--- a/tool/tb_normalize.py
+++ b/tool/tb_normalize.py
@@ -166,7 +166,7 @@ class tbNormalizeTool(Tool): # pylint: disable=invalid-name
 
         return (output_files, output_metadata)
 
-    def run(self, input_files, output_files, metadata=None): # pylint: disable=too-many-locals
+    def run(self, input_files, input_metadata, output_files):  # pylint: disable=too-many-locals
         """
         The main function for the normalization of the Hi-C matrix to a given resolution
 
@@ -219,33 +219,33 @@ class tbNormalizeTool(Tool): # pylint: disable=invalid-name
             logger.info(err)
 
         resolution = '1000000'
-        if 'resolution' in metadata:
-            resolution = metadata['resolution']
+        if 'resolution' in input_metadata:
+            resolution = input_metadata['resolution']
 
         normalization = 'Vanilla'
-        if 'normalization' in metadata:
-            normalization = metadata['normalization']
+        if 'normalization' in input_metadata:
+            normalization = input_metadata['normalization']
 
         min_perc = max_perc = min_count = fasta = mappability = rest_enzyme = None
         ncpus = 1
-        if 'ncpus' in metadata:
-            ncpus = metadata['ncpus']
-        if 'min_perc' in metadata:
-            min_perc = metadata['min_perc']
-        if 'max_perc' in metadata:
-            max_perc = metadata['max_perc']
-        if 'min_count' in metadata:
-            min_count = metadata['min_count']
-        if 'fasta' in metadata:
-            fasta = metadata['fasta']
-        if 'mappability' in metadata:
-            mappability = metadata['mappability']
-        if 'rest_enzyme' in metadata:
-            rest_enzyme = metadata['rest_enzyme']
+        if 'ncpus' in input_metadata:
+            ncpus = input_metadata['ncpus']
+        if 'min_perc' in input_metadata:
+            min_perc = input_metadata['min_perc']
+        if 'max_perc' in input_metadata:
+            max_perc = input_metadata['max_perc']
+        if 'min_count' in input_metadata:
+            min_count = input_metadata['min_count']
+        if 'fasta' in input_metadata:
+            fasta = input_metadata['fasta']
+        if 'mappability' in input_metadata:
+            mappability = input_metadata['mappability']
+        if 'rest_enzyme' in input_metadata:
+            rest_enzyme = input_metadata['rest_enzyme']
 
         root_name = os.path.dirname(os.path.abspath(bamin))
-        if 'workdir' in metadata:
-            root_name = metadata['workdir']
+        if 'workdir' in input_metadata:
+            root_name = input_metadata['workdir']
 
         # input and output share most metadata
 

--- a/tool/tb_normalize.py
+++ b/tool/tb_normalize.py
@@ -39,12 +39,13 @@ except ImportError:
 
     from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN  # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
-    # from utils.dummy_pycompss import compss_wait_on # pylint: disable=ungrouped-imports
+    # from utils.dummy_pycompss import compss_wait_on  # pylint: disable=ungrouped-imports
     # from utils.dummy_pycompss import constraint
+
 
 # ------------------------------------------------------------------------------
 
-class tbNormalizeTool(Tool): # pylint: disable=invalid-name
+class tbNormalizeTool(Tool):  # pylint: disable=invalid-name
     """
     Tool for normalizing an adjacency matrix
     """
@@ -103,7 +104,7 @@ class tbNormalizeTool(Tool): # pylint: disable=invalid-name
             Location of filtered_bins png
 
         """
-        #chr_hic_data = read_matrix(matrix_file, resolution=int(resolution))
+        # chr_hic_data = read_matrix(matrix_file, resolution=int(resolution))
 
         logger.info("TB NORMALIZATION: {0} {1} {2} {3} {4} {5}".format(
             bamin, normalization, resolution, min_perc, max_perc, workdir))

--- a/tool/tb_normalize.py
+++ b/tool/tb_normalize.py
@@ -31,16 +31,16 @@ try:
         raise ImportError
     from pycompss.api.parameter import FILE_IN, FILE_OUT, IN
     from pycompss.api.task import task
-    #from pycompss.api.api import compss_wait_on
+    # from pycompss.api.api import compss_wait_on
     # from pycompss.api.constraint import constraint
 except ImportError:
     logger.info("[Warning] Cannot import \"pycompss\" API packages.")
     logger.info("          Using mock decorators.")
 
-    from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN # pylint: disable=ungrouped-imports
-    from utils.dummy_pycompss import task # pylint: disable=ungrouped-imports
-    #from utils.dummy_pycompss import compss_wait_on # pylint: disable=ungrouped-imports
-    #from utils.dummy_pycompss import constraint
+    from utils.dummy_pycompss import FILE_IN, FILE_OUT, IN  # pylint: disable=ungrouped-imports
+    from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
+    # from utils.dummy_pycompss import compss_wait_on # pylint: disable=ungrouped-imports
+    # from utils.dummy_pycompss import constraint
 
 # ------------------------------------------------------------------------------
 

--- a/tool/tb_parse_mapping.py
+++ b/tool/tb_parse_mapping.py
@@ -19,10 +19,6 @@ from __future__ import print_function
 
 import sys
 
-from pytadbit.parsers.genome_parser import parse_fasta  # pylint: disable=import-error
-from pytadbit.parsers.map_parser import parse_map  # pylint: disable=import-error
-from pytadbit.mapping import get_intersection  # pylint: disable=import-error
-
 from basic_modules.tool import Tool
 
 from utils import logger
@@ -42,6 +38,10 @@ except ImportError:
     from utils.dummy_pycompss import task  # pylint: disable=ungrouped-imports
     # from utils.dummy_pycompss import constraint  # pylint: disable=ungrouped-imports
     from utils.dummy_pycompss import compss_wait_on  # pylint: disable=ungrouped-imports
+
+from pytadbit.parsers.genome_parser import parse_fasta  # pylint: disable=import-error
+from pytadbit.parsers.map_parser import parse_map  # pylint: disable=import-error
+from pytadbit.mapping import get_intersection  # pylint: disable=import-error
 
 
 # ------------------------------------------------------------------------------

--- a/tool/tb_parse_mapping.py
+++ b/tool/tb_parse_mapping.py
@@ -388,7 +388,8 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
                     }
                     return ([], output_metadata)
                 return ([read_iter], output_metadata)
-            elif mapping_list[0] == 'frag':
+
+            if mapping_list[0] == 'frag':
                 window1_full = input_files[1]
                 window1_frag = input_files[2]
 
@@ -415,7 +416,7 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
 
             reads = None
             return ([reads], output_metadata)
-        else:
-            return ([], [])
+
+        return ([], [])
 
 # ------------------------------------------------------------------------------

--- a/tool/tb_parse_mapping.py
+++ b/tool/tb_parse_mapping.py
@@ -378,7 +378,8 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
                     genome_seq, enzyme_name,
                     window1_1, window1_2, window1_3, window1_4,
                     window2_1, window2_2, window2_3, window2_4,
-                    read_iter, ncpus=(1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))  # pylint: disable=line-too-long
+                    read_iter, ncpus=(
+                        1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))
                 results = compss_wait_on(results)
                 if results == 0:
                     output_metadata = {
@@ -387,7 +388,6 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
                     }
                     return ([], output_metadata)
                 return ([read_iter], output_metadata)
-
             elif mapping_list[0] == 'frag':
                 window1_full = input_files[1]
                 window1_frag = input_files[2]
@@ -401,7 +401,8 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
                     genome_seq, enzyme_name,
                     window1_full, window1_frag,
                     window2_full, window2_frag,
-                    read_frag, ncpus=(1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))  # pylint: disable=line-too-long
+                    read_frag, ncpus=(
+                        1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))
 
                 results = compss_wait_on(results)
                 if results == 0:
@@ -414,7 +415,7 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
 
             reads = None
             return ([reads], output_metadata)
-
-        return ([], [])
+        else:
+            return ([], [])
 
 # ------------------------------------------------------------------------------

--- a/tool/tb_parse_mapping.py
+++ b/tool/tb_parse_mapping.py
@@ -414,4 +414,6 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
             reads = None
             return ([reads], output_metadata)
 
+        return ([], [])
+
 # ------------------------------------------------------------------------------

--- a/tool/tb_parse_mapping.py
+++ b/tool/tb_parse_mapping.py
@@ -46,7 +46,7 @@ except ImportError:
 
 # ------------------------------------------------------------------------------
 
-class tbParseMappingTool(Tool):
+class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
     """
     Tool for parsing the mapped reads and generating the list of paired ends
     that have a match at both ends.
@@ -213,7 +213,7 @@ class tbParseMappingTool(Tool):
 
         return counts
 
-    def run(self, input_files, output_files, metadata=None):  # pylint: disable=too-many-locals
+    def run(self, input_files, input_metadata, output_files):  # pylint: disable=too-many-locals
         """
         The main function to map the aligned reads and return the matching
         pairs. Parsing of the mappings can be either iterative of fragment
@@ -324,12 +324,12 @@ class tbParseMappingTool(Tool):
 
         genome_file = input_files[0]
 
-        enzyme_name = metadata['enzyme_name']
-        mapping_list = metadata['mapping']
-        expt_name = metadata['expt_name']
+        enzyme_name = input_metadata['enzyme_name']
+        mapping_list = input_metadata['mapping']
+        expt_name = input_metadata['expt_name']
         filter_chrom = None
-        if 'chromosomes' in metadata and metadata['chromosomes'] != '':
-            filter_chrom = metadata['chromosomes'].split(',')
+        if 'chromosomes' in input_metadata and input_metadata['chromosomes'] != '':
+            filter_chrom = input_metadata['chromosomes'].split(',')
 
         root_name = input_files[1].split("/")
 
@@ -377,7 +377,7 @@ class tbParseMappingTool(Tool):
                     genome_seq, enzyme_name,
                     window1_1, window1_2, window1_3, window1_4,
                     window2_1, window2_2, window2_3, window2_4,
-                    read_iter, ncpus=(1 if 'ncpus' not in metadata else metadata['ncpus']))
+                    read_iter, ncpus=(1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))
                 results = compss_wait_on(results)
                 if results == 0:
                     output_metadata = {
@@ -400,7 +400,7 @@ class tbParseMappingTool(Tool):
                     genome_seq, enzyme_name,
                     window1_full, window1_frag,
                     window2_full, window2_frag,
-                    read_frag, ncpus=(1 if 'ncpus' not in metadata else metadata['ncpus']))
+                    read_frag, ncpus=(1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))
 
                 results = compss_wait_on(results)
                 if results == 0:

--- a/tool/tb_parse_mapping.py
+++ b/tool/tb_parse_mapping.py
@@ -377,11 +377,11 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
                     genome_seq, enzyme_name,
                     window1_1, window1_2, window1_3, window1_4,
                     window2_1, window2_2, window2_3, window2_4,
-                    read_iter, ncpus=(1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))
+                    read_iter, ncpus=(1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))  # pylint: disable=line-too-long
                 results = compss_wait_on(results)
                 if results == 0:
                     output_metadata = {
-                        'error' : 'No interactions found, \
+                        'error': 'No interactions found, \
                         please verify input data and chromosome filtering'
                     }
                     return ([], output_metadata)
@@ -400,7 +400,7 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
                     genome_seq, enzyme_name,
                     window1_full, window1_frag,
                     window2_full, window2_frag,
-                    read_frag, ncpus=(1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))
+                    read_frag, ncpus=(1 if 'ncpus' not in input_metadata else input_metadata['ncpus']))  # pylint: disable=line-too-long
 
                 results = compss_wait_on(results)
                 if results == 0:

--- a/tool/tb_parse_mapping.py
+++ b/tool/tb_parse_mapping.py
@@ -335,14 +335,15 @@ class tbParseMappingTool(Tool):  # pylint: disable=invalid-name
 
         reads = "/".join(root_name[0:-1]) + '/'
 
-        genome_seq = parse_fasta(
+        genome_seq = parse_fasta(  # pylint: disable=unexpected-keyword-arg
             genome_file, chr_filter=filter_chrom,
             chr_regexp="^(chr)?[A-Za-z]?[0-9]{0,3}[XVI]{0,3}(?:ito)?[A-Z-a-z]?$",
             save_cache=False, reload_cache=True)
 
         if not genome_seq:
-            genome_seq = parse_fasta(genome_file, chr_filter=filter_chrom,
-                                     save_cache=False, reload_cache=True)
+            genome_seq = parse_fasta(  # pylint: disable=unexpected-keyword-arg
+                genome_file, chr_filter=filter_chrom,
+                save_cache=False, reload_cache=True)
             if not genome_seq:
                 logger.fatal("Reference genome FASTA file does not contain any valid chromosome")
                 raise ValueError('No valid chromosomes in FASTA.')

--- a/tool/tb_segment.py
+++ b/tool/tb_segment.py
@@ -141,7 +141,7 @@ class tbSegmentTool(Tool):  # pylint: disable=invalid-name
 
         return (output_files, output_metadata)
 
-    def run(self, input_files, output_files, metadata=None):  # pylint: disable=too-many-locals
+    def run(self, input_files, input_metadata, output_files):   # pylint: disable=too-many-locals
         """
         The main function to the predict TAD sites and compartments for a given resolution from
         the Hi-C matrix
@@ -182,26 +182,26 @@ class tbSegmentTool(Tool):  # pylint: disable=invalid-name
             logger.info(err)
 
         resolution = '1000000'
-        if 'resolution' in metadata:
-            resolution = metadata['resolution']
+        if 'resolution' in input_metadata:
+            resolution = input_metadata['resolution']
 
         ncpus = 1
-        if 'ncpus' in metadata:
-            ncpus = metadata['ncpus']
+        if 'ncpus' in input_metadata:
+            ncpus = input_metadata['ncpus']
         biases = chromosomes = fasta = None
         if len(input_files) > 1:
             biases = input_files[1]
-        if "chromosomes" in metadata:
-            chromosomes = metadata['chromosomes']
-        if "fasta" in metadata:
-            fasta = metadata['fasta']
+        if "chromosomes" in input_metadata:
+            chromosomes = input_metadata['chromosomes']
+        if "fasta" in input_metadata:
+            fasta = input_metadata['fasta']
         callers = "1"
-        if "callers" in metadata:
-            callers = metadata['callers']
+        if "callers" in input_metadata:
+            callers = input_metadata['callers']
 
         root_name = os.path.dirname(os.path.abspath(bamin))
-        if 'workdir' in metadata:
-            root_name = metadata['workdir']
+        if 'workdir' in input_metadata:
+            root_name = input_metadata['workdir']
 
         # input and output share most metadata
 

--- a/tool/trimgalore.py
+++ b/tool/trimgalore.py
@@ -193,10 +193,11 @@ class trimgalore(Tool):  # pylint: disable=invalid-name
                 with open(trimmed_report, "rb") as f_in:
                     f_out.write(f_in.read())
         except (OSError, IOError) as error:
-            logger.fatal("I/O error({0}) - TRIMMING REPORT FASTQ 1: {1}\nWRITE: {2}\nREAD: {3}".format(
-                error.errno, error.strerror, fastq_report,
-                trimmed_report
-            ))
+            logger.fatal(
+                "I/O error({0}) - TRIMMING REPORT FASTQ 1: {1}\nWRITE: {2}\nREAD: {3}".format(
+                    error.errno, error.strerror, fastq_report,
+                    trimmed_report
+                ))
             return False
 
         return True

--- a/tool/trimgalore.py
+++ b/tool/trimgalore.py
@@ -186,12 +186,11 @@ class trimgalore(Tool):  # pylint: disable=invalid-name
             return False
 
         try:
+            trimmed_report = os.path.join(
+                fastq_trimmed[0], "tmp", fastq_trimmed[1] + "_trimming_report.txt"
+            )
             with open(fastq_report, "wb") as f_out:
-                with open(
-                    os.path.join(
-                        fastq_trimmed[0], "tmp", fastq_trimmed[1] + "_trimming_report.txt"
-                    ), "rb"
-                ) as f_in:
+                with open(trimmed_report, "rb") as f_in:
                     f_out.write(f_in.read())
         except (OSError, IOError) as error:
             logger.fatal("I/O error({0}) - TRIMMING REPORT FASTQ 1: {1}\n{2}\n{3}".format(
@@ -304,20 +303,18 @@ class trimgalore(Tool):  # pylint: disable=invalid-name
                 with open(tg_tmp_out_2, "rb") as f_in:
                     f_out.write(f_in.read())
 
+            trimmed_report_1 = os.path.join(
+                fastq1_trimmed[0], "tmp", fastq1_trimmed[1] + "_trimming_report.txt"
+            )
+            trimmed_report_2 = os.path.join(
+                fastq2_trimmed[0], "tmp", fastq2_trimmed[1] + "_trimming_report.txt"
+            )
             with open(fastq1_report, "wb") as f_out:
-                with open(
-                    os.path.join(
-                        fastq1_trimmed[0], "tmp", fastq1_trimmed[1] + "_trimming_report.txt"
-                    ), "rb"
-                ) as f_in:
+                with open(trimmed_report_1, "rb") as f_in:
                     f_out.write(f_in.read())
 
             with open(fastq2_report, "wb") as f_out:
-                with open(
-                    os.path.join(
-                        fastq2_trimmed[0], "tmp", fastq2_trimmed[1] + "_trimming_report.txt"
-                    ), "rb"
-                ) as f_in:
+                with open(trimmed_report_2, "rb") as f_in:
                     f_out.write(f_in.read())
         except (OSError, IOError) as error:
             logger.fatal("I/O error({0}) - Missing output file: {1}".format(

--- a/tool/trimgalore.py
+++ b/tool/trimgalore.py
@@ -187,17 +187,15 @@ class trimgalore(Tool):  # pylint: disable=invalid-name
 
         try:
             trimmed_report = os.path.join(
-                fastq_trimmed[0], "tmp", fastq_trimmed[1] + "_trimming_report.txt"
+                fastq_trimmed[0], fastq_trimmed[1] + "_trimming_report.txt"
             )
             with open(fastq_report, "wb") as f_out:
                 with open(trimmed_report, "rb") as f_in:
                     f_out.write(f_in.read())
         except (OSError, IOError) as error:
-            logger.fatal("I/O error({0}) - TRIMMING REPORT FASTQ 1: {1}\n{2}\n{3}".format(
+            logger.fatal("I/O error({0}) - TRIMMING REPORT FASTQ 1: {1}\nWRITE: {2}\nREAD: {3}".format(
                 error.errno, error.strerror, fastq_report,
-                os.path.join(
-                    fastq_trimmed[0], fastq_trimmed[1] + "_trimming_report.txt"
-                )
+                trimmed_report
             ))
             return False
 
@@ -308,10 +306,10 @@ class trimgalore(Tool):  # pylint: disable=invalid-name
                     f_out.write(f_in.read())
 
             trimmed_report_1 = os.path.join(
-                fastq1_trimmed[0], "tmp", fastq1_trimmed[1] + "_trimming_report.txt"
+                fastq1_trimmed[0], fastq1_trimmed[1] + "_trimming_report.txt"
             )
             trimmed_report_2 = os.path.join(
-                fastq2_trimmed[0], "tmp", fastq2_trimmed[1] + "_trimming_report.txt"
+                fastq2_trimmed[0], fastq2_trimmed[1] + "_trimming_report.txt"
             )
             with open(fastq1_report, "wb") as f_out:
                 with open(trimmed_report_1, "rb") as f_in:


### PR DESCRIPTION
Hi David,

A while back there was a change to the run() in the Tool API to the order of the parameters.

Was: `run(in_files, out_files, metadata)`
Now: `run(in_files, metadata, out_files)`

This is for both the Tool and Workflow definitions.

This branch includes the changes to convert the tools and the pipelines.

If the changes look fine to you and they are still viable then they can be merged into the tadbit_tools_update. At which point that can then get merged into master

Cheers,

Mark